### PR TITLE
Bug fixes

### DIFF
--- a/vector3i.h
+++ b/vector3i.h
@@ -138,8 +138,8 @@ _FORCE_INLINE_ bool operator!=(const Vector3i & a, const Vector3i & b) {
 struct Vector3iHasher {
 	static _FORCE_INLINE_ uint32_t hash(const Vector3i & v) {
 		uint32_t hash = hash_djb2_one_32(v.x);
-		hash = hash_djb2_one_32(v.y);
-		return hash_djb2_one_32(v.z);
+		hash = hash_djb2_one_32(v.y, hash);
+		return hash_djb2_one_32(v.z, hash);
     }
 };
 

--- a/voxel_buffer.cpp
+++ b/voxel_buffer.cpp
@@ -65,12 +65,13 @@ void VoxelBuffer::set_voxel(int value, int x, int y, int z, unsigned int channel
 
     Channel & channel = _channels[channel_index];
 
-    if (channel.defval != value) {
+    //FIX: if VOXEL_AT(channel.data, x, y, z) is not channel.defval we have to set that voxel nethertheless
+    //if (channel.defval != value) {
         if (channel.data == NULL) {
             create_channel(channel_index, _size);
         }
         VOXEL_AT(channel.data, x, y, z) = value;
-    }
+    //}
 }
 
 void VoxelBuffer::set_voxel_v(int value, Vector3 pos, unsigned int channel_index) {

--- a/voxel_map.cpp
+++ b/voxel_map.cpp
@@ -51,9 +51,10 @@ VoxelBlock * VoxelBlock::create(VoxelMap & map, Vector3i bpos, VoxelBuffer * buf
 
 void VoxelMap::set_voxel(int value, Vector3i pos, unsigned int c) {
     Vector3i bpos = voxel_to_block(pos);
-    VoxelBlock * block = get_block(pos);
+    VoxelBlock * block = get_block(bpos);
     if (block == NULL) {
-        set_block(bpos, VoxelBlock::create(*this, bpos));
+    	block = VoxelBlock::create(*this, bpos);
+        set_block(bpos, block);
     }
     block->voxels->set_voxel(value, pos - block_to_voxel(bpos), c);
 }


### PR DESCRIPTION
**Fixed hash calculation in Vector3i:**
Hash was only calculated from one coordinate. Should be calculated from all three coordinates.

**Fixed null pointer in set_voxel:**
The get_block call needs the block position and not the voxel position
Crashed if block is null, because the pointer is not set the newly created VoxelBlock.

**Fixed change voxel type in VoxelBuffer:**
If the current voxel type differs from the default type and you want to set the voxel to type=default_type nothing happend.