### PR TITLE
Remove line from utility.h: #include <core/dvector.h>

### DIFF
--- a/utility.h
+++ b/utility.h
@@ -2,7 +2,6 @@
 #define HEADER_VOXEL_UTILITY_H
 
 #include <core/vector.h>
-#include <core/dvector.h>
 #include <core/ustring.h>
 #include "vector3i.h"
 


### PR DESCRIPTION
Remove #include <core/dvector.h> to avoid compilation error with Godot's latest 3.1 stable release

After the change, the engine compiled successfully and I was able to open and run the Zylann/voxelgame project