### PR TITLE
Raycast for VoxelLodTerrain

### DIFF
--- a/terrain/voxel_lod_terrain.cpp
+++ b/terrain/voxel_lod_terrain.cpp
@@ -796,10 +796,27 @@ static bool _raycast_binding_predicate(Vector3i pos, void *context_ptr) {
 	_VoxelLodTerrainRaycastContext *context = (_VoxelLodTerrainRaycastContext *)context_ptr;
 	VoxelLodTerrain &terrain = context->terrain;
 
-	Ref<VoxelMap> map = terrain.get_map();
 
-	float v1 = map->get_voxel_f(pos.x, pos.y, pos.z, Voxel::CHANNEL_ISOLEVEL);
-	return v1 < 0;
+	float value = 0.0;
+
+	int lods = terrain.get_lod_count();
+	//printf("Lod-Raycast: Lod count=%d\n", lods);
+	for (int i = 0; i < lods; i++) {
+		//printf("Lod-Raycast: Getting map %d\n", i);
+		Ref<VoxelMap> map = terrain.get_map(i);
+		if (map != nullptr) {
+			//printf("Lod-Raycast: Found map %d\n", i);
+			float v1 = map->get_voxel_f(pos.x, pos.y, pos.z, Voxel::CHANNEL_ISOLEVEL);
+			//printf("Lod-Raycast: Ray cast value v1: %f\n", v1);
+			value = v1;
+			if (v1 < 0) {
+				//printf("Lod-Raycast: Found on map %d, value %f\n", i, value);
+				return true;
+			}
+		}
+	}
+	return false;
+
 }
 
 Variant VoxelLodTerrain::_raycast_binding(Vector3 origin, Vector3 direction, real_t max_distance) {

--- a/terrain/voxel_lod_terrain.h
+++ b/terrain/voxel_lod_terrain.h
@@ -45,6 +45,8 @@ public:
 	Dictionary get_block_info(Vector3 fbpos, unsigned int lod_index) const;
 	Vector3 voxel_to_block_position(Vector3 vpos, unsigned int lod_index) const;
 
+	Ref<VoxelMap> get_map() { return _lods[0].map; }
+
 	struct Stats {
 		VoxelMeshUpdater::Stats updater;
 		VoxelDataLoader::Stats stream;
@@ -76,6 +78,7 @@ private:
 	Vector3 get_viewer_pos(Vector3 &out_direction) const;
 	void try_schedule_loading_with_neighbors(const Vector3i &p_bpos, unsigned int lod_index);
 	bool check_block_loaded_and_updated(const Vector3i &p_bpos, unsigned int lod_index);
+	Variant _raycast_binding(Vector3 origin, Vector3 direction, real_t max_distance);
 
 	template <typename A>
 	void for_all_blocks(A &action) {

--- a/terrain/voxel_lod_terrain.h
+++ b/terrain/voxel_lod_terrain.h
@@ -45,7 +45,7 @@ public:
 	Dictionary get_block_info(Vector3 fbpos, unsigned int lod_index) const;
 	Vector3 voxel_to_block_position(Vector3 vpos, unsigned int lod_index) const;
 
-	Ref<VoxelMap> get_map() { return _lods[0].map; }
+	Ref<VoxelMap> get_map(unsigned int lod_index) { return _lods[lod_index].map; }
 
 	struct Stats {
 		VoxelMeshUpdater::Stats updater;


### PR DESCRIPTION
This patch copies the raycast function from VoxelTerrain to VoxelLodTerrain, with appropriate updates to make it work. Please let me know if it's ok or needs adjustment.

The only issue with it is that it only raycasts on LOD 0. I experimented with other LODs and had mixed results from crashing on LOD 8, to not hitting on LOD 1. 

In game, it works as well as the raycasting on VoxelTerrain, once LOD 0 is loaded. So it's possible to fall through the local environment in the first few seconds, but once loaded, it's fine. 

Raycast collision makes a playable terrain until full physics can be developed. The LOD terrain is great so far and allows an older system like mine (Intel HD4400 laptop) to have a pretty far visual depth (1000) at a decent framerate (30-48fps even with short shadows).

~~If you want to see it in action, check out my branch here:
https://github.com/tinmanjuggernaut/voxelgame/tree/fps_demo~~
(Edit: this demo now uses physics based collision)

## Instructions
* Run heightmap.tscn to see raycast collision as is without this patch. 
* lod_noise.tscn needs this patch, but basically works the same. It uses 3D noise on the LOD terrain.
* This uses an input map defined in project.godot.
* Press 'F' to toggle between first and third person.
* W/A/S/D, space for jump or hold for jetpack. If you fall into the terrain, jetpack will push you up.


![LOD-noise](https://user-images.githubusercontent.com/632766/58759811-f67e2300-856a-11e9-93da-3a8ab2391a4e.jpg)

