### PR TITLE
Emerge bugfix

### DIFF
--- a/streams/voxel_stream.cpp
+++ b/streams/voxel_stream.cpp
@@ -10,8 +10,15 @@ void VoxelStream::emerge_block(Ref<VoxelBuffer> out_buffer, Vector3i origin_in_v
 		Variant arg2 = origin_in_voxels.to_vec3();
 		Variant arg3 = lod;
 		const Variant *args[3] = { &arg1, &arg2, &arg3 };
-		//Variant::CallError err; // wut
-		script->call("emerge_block", args, 3);
+		Variant::CallError err;
+		script->call("emerge_block", args, 3, err);
+		if (err.error != Variant::CallError::CALL_OK) {
+			ERR_EXPLAIN(String("voxel_stream.cpp:emerge_block gave an error: ") + String::num(err.error)
+				+ String(" Argument: ") + String::num(err.argument)
+				+ String(" Expected type: ") + String(Variant::get_type_name(err.expected)));
+			ERR_FAIL();
+			// This had to be explicitely logged due to the usual GD debugger not working with threads
+		}
 	}
 }
 
@@ -24,8 +31,15 @@ void VoxelStream::immerge_block(Ref<VoxelBuffer> buffer, Vector3i origin_in_voxe
 		Variant arg2 = origin_in_voxels.to_vec3();
 		Variant arg3 = lod;
 		const Variant *args[3] = { &arg1, &arg2, &arg3 };
-		//Variant::CallError err; // wut
-		script->call("immerge_block", args, 3);
+		Variant::CallError err;
+		script->call("immerge_block", args, 3, err);
+		if (err.error != Variant::CallError::CALL_OK) {
+			ERR_EXPLAIN(String("voxel_stream.cpp:immerge_block gave an error: ") + String::num(err.error)
+				+ String(" Argument: ") + String::num(err.argument)
+				+ String(" Expected type: ") + String(Variant::get_type_name(err.expected)));
+			ERR_FAIL();
+			// This had to be explicitely logged due to the usual GD debugger not working with threads
+		}
 	}
 }
 

--- a/voxel.cpp
+++ b/voxel.cpp
@@ -267,7 +267,7 @@ void Voxel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_geometry_type", "type"), &Voxel::set_geometry_type);
 	ClassDB::bind_method(D_METHOD("get_geometry_type"), &Voxel::get_geometry_type);
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "voxel_name"), "set_name", "get_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "voxel_name"), "set_voxel_name", "get_voxel_name");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_color", "get_color");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "transparent"), "set_transparent", "is_transparent");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "material_id"), "set_material_id", "get_material_id");


### PR DESCRIPTION
Fixes two small bugs:

1. Voxel_name bindings were incorrect, which meant you couldn't read/write the variable like `print(voxel.voxel_name)`.

2. Calling emerge used the wrong overloaded version and resulted in a returned error, thus the call never got to the script.

fixes #30 