### PR TITLE
Add Full Collision

### DIFF
--- a/terrain/voxel_block.h
+++ b/terrain/voxel_block.h
@@ -4,6 +4,9 @@
 #include "../util/direct_mesh_instance.h"
 #include "../voxel_buffer.h"
 
+#include <scene/3d/collision_shape.h>
+#include <scene/3d/physics_body.h>
+
 // Internal structure holding a reference to mesh visuals, physics and a block of voxel data.
 class VoxelBlock {
 public:
@@ -40,6 +43,9 @@ public:
 		return _mesh_state == MESH_UPDATE_NOT_SENT || _mesh_state == MESH_UPDATE_SENT;
 	}
 
+	void generate_collision(Node* parent);
+	void destroy_collision();
+
 private:
 	VoxelBlock();
 
@@ -54,6 +60,9 @@ private:
 	// The mesh might be null, but we don't know if it's actually empty or if it's loading.
 	// This boolean tells if we attempted to mesh this block at least once.
 	bool _has_been_meshed = false;
+
+	StaticBody* _static_body = NULL;
+	Node* _parent = NULL;
 };
 
 #endif // VOXEL_BLOCK_H

--- a/terrain/voxel_lod_terrain.cpp
+++ b/terrain/voxel_lod_terrain.cpp
@@ -20,6 +20,8 @@ VoxelLodTerrain::VoxelLodTerrain() {
 
 	set_lod_count(8);
 	set_lod_split_scale(3);
+
+	_generate_collision = true;
 }
 
 VoxelLodTerrain::~VoxelLodTerrain() {
@@ -33,6 +35,14 @@ VoxelLodTerrain::~VoxelLodTerrain() {
 	if (_block_updater) {
 		memdelete(_block_updater);
 	}
+}
+
+void VoxelLodTerrain::set_generate_collision(bool enabled) {
+	_generate_collision = enabled;
+}
+
+bool VoxelLodTerrain::get_generate_collision() const {
+	return _generate_collision;
 }
 
 Ref<Material> VoxelLodTerrain::get_material() const {
@@ -890,6 +900,10 @@ void VoxelLodTerrain::_process() {
 
 			block->set_mesh(mesh, world);
 			block->mark_been_meshed();
+
+			if (_generate_collision) {
+				block->generate_collision(this);
+			}
 		}
 
 		shift_up(_blocks_pending_main_thread_update, queue_index);
@@ -925,6 +939,9 @@ void VoxelLodTerrain::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_stream", "stream"), &VoxelLodTerrain::set_stream);
 	ClassDB::bind_method(D_METHOD("get_stream"), &VoxelLodTerrain::get_stream);
 
+	ClassDB::bind_method(D_METHOD("get_generate_collision"), &VoxelLodTerrain::get_generate_collision);
+	ClassDB::bind_method(D_METHOD("set_generate_collision", "enabled"), &VoxelLodTerrain::set_generate_collision);
+
 	ClassDB::bind_method(D_METHOD("set_material", "material"), &VoxelLodTerrain::set_material);
 	ClassDB::bind_method(D_METHOD("get_material"), &VoxelLodTerrain::get_material);
 
@@ -952,5 +969,6 @@ void VoxelLodTerrain::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "lod_count"), "set_lod_count", "get_lod_count");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "lod_split_scale"), "set_lod_split_scale", "get_lod_split_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "viewer_path"), "set_viewer_path", "get_viewer_path");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "generate_collision"), "set_generate_collision", "get_generate_collision");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "Material"), "set_material", "get_material");
 }

--- a/terrain/voxel_lod_terrain.h
+++ b/terrain/voxel_lod_terrain.h
@@ -23,6 +23,9 @@ public:
 	VoxelLodTerrain();
 	~VoxelLodTerrain();
 
+	void set_generate_collision(bool enabled);
+	bool get_generate_collision() const;
+
 	Ref<Material> get_material() const;
 	void set_material(Ref<Material> p_material);
 
@@ -108,6 +111,8 @@ private:
 	VoxelDataLoader *_stream_thread = nullptr;
 	VoxelMeshUpdater *_block_updater = nullptr;
 	std::vector<VoxelMeshUpdater::OutputBlock> _blocks_pending_main_thread_update;
+
+	bool _generate_collision;
 
 	Ref<Material> _material;
 

--- a/terrain/voxel_terrain.cpp
+++ b/terrain/voxel_terrain.cpp
@@ -25,7 +25,7 @@ VoxelTerrain::VoxelTerrain() {
 	_stream_thread = NULL;
 	_block_updater = NULL;
 
-	_generate_collisions = false;
+	_generate_collision = true;
 	_run_in_editor = false;
 	_smooth_meshing_enabled = false;
 }
@@ -197,8 +197,12 @@ void VoxelTerrain::set_voxel_library(Ref<VoxelLibrary> library) {
 	make_all_view_dirty_deferred();
 }
 
-void VoxelTerrain::set_generate_collisions(bool enabled) {
-	_generate_collisions = enabled;
+void VoxelTerrain::set_generate_collision(bool enabled) {
+	_generate_collision = enabled;
+}
+
+bool VoxelTerrain::get_generate_collision() const {
+	return _generate_collision;
 }
 
 int VoxelTerrain::get_view_distance() const {
@@ -1059,6 +1063,10 @@ void VoxelTerrain::_process() {
 			}
 
 			block->set_mesh(mesh, world);
+
+			if (_generate_collision) {
+				block->generate_collision(this);
+			}
 		}
 
 		shift_up(_blocks_pending_main_thread_update, queue_index);
@@ -1169,8 +1177,8 @@ void VoxelTerrain::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_view_distance", "distance_in_voxels"), &VoxelTerrain::set_view_distance);
 	ClassDB::bind_method(D_METHOD("get_view_distance"), &VoxelTerrain::get_view_distance);
 
-	ClassDB::bind_method(D_METHOD("get_generate_collisions"), &VoxelTerrain::get_generate_collisions);
-	ClassDB::bind_method(D_METHOD("set_generate_collisions", "enabled"), &VoxelTerrain::set_generate_collisions);
+	ClassDB::bind_method(D_METHOD("get_generate_collision"), &VoxelTerrain::get_generate_collision);
+	ClassDB::bind_method(D_METHOD("set_generate_collision", "enabled"), &VoxelTerrain::set_generate_collision);
 
 	ClassDB::bind_method(D_METHOD("get_viewer_path"), &VoxelTerrain::get_viewer_path);
 	ClassDB::bind_method(D_METHOD("set_viewer_path", "path"), &VoxelTerrain::set_viewer_path);
@@ -1197,7 +1205,7 @@ void VoxelTerrain::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "voxel_library", PROPERTY_HINT_RESOURCE_TYPE, "VoxelLibrary"), "set_voxel_library", "get_voxel_library");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "view_distance"), "set_view_distance", "get_view_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "viewer_path"), "set_viewer_path", "get_viewer_path");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "generate_collisions"), "set_generate_collisions", "get_generate_collisions");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "generate_collision"), "set_generate_collision", "get_generate_collision");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "smooth_meshing_enabled"), "set_smooth_meshing_enabled", "is_smooth_meshing_enabled");
 
 	BIND_ENUM_CONSTANT(BLOCK_NONE);

--- a/terrain/voxel_terrain.h
+++ b/terrain/voxel_terrain.h
@@ -46,8 +46,8 @@ public:
 	void make_area_dirty(Rect3i box);
 	bool is_block_dirty(Vector3i bpos) const;
 
-	void set_generate_collisions(bool enabled);
-	bool get_generate_collisions() const { return _generate_collisions; }
+	void set_generate_collision(bool enabled);
+	bool get_generate_collision() const;
 
 	int get_view_distance() const;
 	void set_view_distance(int distance_in_voxels);
@@ -158,7 +158,7 @@ private:
 	Vector3i _last_viewer_block_pos;
 	int _last_view_distance_blocks;
 
-	bool _generate_collisions;
+	bool _generate_collision;
 	bool _run_in_editor;
 	bool _smooth_meshing_enabled;
 


### PR DESCRIPTION
Full collision has been implemented for all terrains (blocky, smooth/dual marching cubes/DMC, and LOD + DMC).

Collision is enabled by default. This can be user set with the `generate_collision` parameter on the terrain node, or by setting the variable in code.

I've tested quite a bit for memory leaks. VoxelLODTerrain maintains 340-380mb of ram usage at the settings below. Even when repeatedly deleting and creating a terrain node with code, everything gets cleaned up.

The editor setting Debug/Visible Collision Shapes works as expected as shown in the first graphic below.

**Performance**
The performance hit is marginal at worst. With or without collision I got these rates:

__GTX 1060__ 
VoxelLODTerrain @ 1024 view distance
4k: 120-170fps
1080p: 300-400fps

VoxelTerrain @ 256 view distance
4k: 100-160fps
1080p: 100-200fps

__Intel 630__
VoxelLODTerrain
4k: 15-20fps
1080p: 45-60fps

VoxelTerrain
4: 12-16fps
1080p: 45-70fps

![heightmap](https://user-images.githubusercontent.com/632766/62386300-61ab9c00-b592-11e9-8f01-3f454593dd91.gif)
![3dnoise](https://user-images.githubusercontent.com/632766/62387050-8ef94980-b594-11e9-836c-37350609858a.gif)
