### PR TITLE
Enables 3D Noise on Blocky VoxelTerrain

### DIFF
--- a/streams/voxel_stream_noise.h
+++ b/streams/voxel_stream_noise.h
@@ -7,7 +7,11 @@
 
 class VoxelStreamNoise : public VoxelStream {
 	GDCLASS(VoxelStreamNoise, VoxelStream)
+
 public:
+	void set_channel(VoxelBuffer::ChannelId channel);
+	VoxelBuffer::ChannelId get_channel() const;
+
 	void set_noise(Ref<OpenSimplexNoise> noise);
 	Ref<OpenSimplexNoise> get_noise() const;
 
@@ -23,6 +27,7 @@ protected:
 	static void _bind_methods();
 
 private:
+	VoxelBuffer::ChannelId _channel = VoxelBuffer::CHANNEL_TYPE;
 	Ref<OpenSimplexNoise> _noise;
 	FloatBuffer3D _noise_buffer;
 	float _height_start = 0;

--- a/terrain/voxel_terrain.cpp
+++ b/terrain/voxel_terrain.cpp
@@ -839,6 +839,7 @@ void VoxelTerrain::_process() {
 			VoxelBlock *block = _map->get_block(block_pos);
 			bool update_neighbors = block == nullptr;
 			block = _map->set_block_buffer(block_pos, ob.data.voxels_loaded);
+			block->set_world(get_world());
 
 			// TODO The following code appears to have order-dependency with block loading.
 			// i.e if block loading responses arrive in a different order they were requested in,


### PR DESCRIPTION
Adds 3D noise functionality to blocky voxel terrain.

![image](https://user-images.githubusercontent.com/632766/72161661-7b7fc380-33fb-11ea-8054-d891d6795936.png)

This PR includes the previous one which fixes voxel terrain visibility. I'm not sure if it will automatically go away when you merge, or if I need to pull it out of the PR.


Fixes #80 