### PR TITLE
Fixed cannot place blocks on transparent blocks

### DIFF
--- a/edition/voxel_tool_terrain.cpp
+++ b/edition/voxel_tool_terrain.cpp
@@ -40,6 +40,9 @@ Ref<VoxelRaycastResult> VoxelToolTerrain::raycast(Vector3 pos, Vector3 dir, floa
 			if (voxel.is_transparent() == false)
 				return true;
 
+			if (voxel.is_transparent() && voxel.get_collision_aabbs().empty() == false)
+				return true;
+
 			float v1 = map->get_voxel_f(pos, VoxelBuffer::CHANNEL_SDF);
 			return v1 < 0;
 		}

--- a/edition/voxel_tool_terrain.cpp
+++ b/edition/voxel_tool_terrain.cpp
@@ -37,6 +37,9 @@ Ref<VoxelRaycastResult> VoxelToolTerrain::raycast(Vector3 pos, Vector3 dir, floa
 				return false;
 
 			const Voxel &voxel = lib.get_voxel_const(v0);
+			if (voxel.get_geometry_type() == voxel.GEOMETRY_NONE)
+				return false;
+
 			if (voxel.is_transparent() == false)
 				return true;
 


### PR DESCRIPTION
Not sure if this is the right way of fixing this, but I have some transparent blocks like glass or leaves that I still want to place other blocks onto, but the raycast method ignored them. This is my quick, but there might be better solution like maybe having some sort of raycast option in the VoxelLibrary.

Closes issue #153 