### PR TITLE
Fix autosave on window close not working

### DIFF
--- a/terrain/block_thread_manager.h
+++ b/terrain/block_thread_manager.h
@@ -374,7 +374,7 @@ private:
 
 	static void thread_func(JobData &data) {
 
-		while (!data.thread_exit) {
+		while (true) {
 
 			uint32_t sync_time = OS::get_singleton()->get_ticks_msec() + data.sync_interval_ms;
 


### PR DESCRIPTION
See https://github.com/Zylann/godot_voxel/issues/146, this PR fixes the autosaving bug. What was happening, was the truth value of `data.thread_exit` could be changed by main thread while child thread was inside loop.