### PR TITLE
Fix warnings

### DIFF
--- a/editor/graph/voxel_graph_editor.cpp
+++ b/editor/graph/voxel_graph_editor.cpp
@@ -227,10 +227,10 @@ void VoxelGraphEditor::create_node_gui(uint32_t node_id) {
 	//node_view.resizable = true
 	//node_view.rect_size = Vector2(200, 100)
 
-	const int row_count = max(node_type.inputs.size(), node_type.outputs.size());
+	const unsigned int row_count = max(node_type.inputs.size(), node_type.outputs.size());
 	const Color port_color(0.4, 0.4, 1.0);
 
-	for (int i = 0; i < row_count; ++i) {
+	for (unsigned int i = 0; i < row_count; ++i) {
 		const bool has_left = i < node_type.inputs.size();
 		const bool has_right = i < node_type.outputs.size();
 

--- a/generators/graph/voxel_generator_graph.cpp
+++ b/generators/graph/voxel_generator_graph.cpp
@@ -400,7 +400,7 @@ Dictionary VoxelGeneratorGraph::get_graph_as_variant_data() {
 static bool var_to_id(Variant v, uint32_t &out_id, uint32_t min = 0) {
 	ERR_FAIL_COND_V(v.get_type() != Variant::INT, false);
 	int i = v;
-	ERR_FAIL_COND_V(i < min, false);
+	ERR_FAIL_COND_V(i < 0 || (unsigned int)i < min, false);
 	out_id = i;
 	return true;
 }
@@ -411,7 +411,7 @@ void VoxelGeneratorGraph::load_graph_from_variant_data(Dictionary data) {
 	const VoxelGraphNodeDB &type_db = *VoxelGraphNodeDB::get_singleton();
 
 	const Variant *id_key = nullptr;
-	while (id_key = nodes_data.next(id_key)) {
+	while ((id_key = nodes_data.next(id_key))) {
 		const String id_str = *id_key;
 		ERR_FAIL_COND(!id_str.is_valid_integer());
 		const int sid = id_str.to_int();
@@ -428,7 +428,7 @@ void VoxelGeneratorGraph::load_graph_from_variant_data(Dictionary data) {
 		ERR_FAIL_COND(node == nullptr);
 
 		const Variant *param_key = nullptr;
-		while (param_key = node_data.next(param_key)) {
+		while ((param_key = node_data.next(param_key))) {
 			const String param_name = *param_key;
 			if (param_name == "type") {
 				continue;
@@ -541,7 +541,7 @@ bool VoxelGeneratorGraph::_set(const StringName &p_name, const Variant &p_value)
 	struct L {
 		inline static bool set_xyz(char c, Vector3i &p, int v) {
 			int i = c - 'x';
-			ERR_FAIL_COND_V(i < 0 || i >= Vector3i::AXIS_COUNT, false);
+			ERR_FAIL_COND_V(i < 0 || (unsigned int)i >= Vector3i::AXIS_COUNT, false);
 			p[i] = v;
 			return true;
 		}
@@ -596,7 +596,7 @@ bool VoxelGeneratorGraph::_get(const StringName &p_name, Variant &r_ret) const {
 	struct L {
 		inline static bool get_xyz(char c, const Vector3i &p, Variant &r) {
 			int i = c - 'x';
-			ERR_FAIL_COND_V(i < 0 || i >= Vector3i::AXIS_COUNT, false);
+			ERR_FAIL_COND_V(i < 0 || (unsigned int)i >= Vector3i::AXIS_COUNT, false);
 			r = p[i];
 			return true;
 		}

--- a/generators/graph/voxel_graph_node_db.h
+++ b/generators/graph/voxel_graph_node_db.h
@@ -29,8 +29,8 @@ public:
 
 		Param(String p_name, Variant::Type p_type, Variant p_default_value = Variant()) :
 				name(p_name),
-				type(p_type),
-				default_value(p_default_value) {}
+				default_value(p_default_value),
+				type(p_type) {}
 
 		Param(String p_name, String p_class_name) :
 				name(p_name),

--- a/meshers/blocky/voxel.cpp
+++ b/meshers/blocky/voxel.cpp
@@ -98,7 +98,7 @@ Ref<Voxel> Voxel::set_voxel_name(String name) {
 }
 
 Ref<Voxel> Voxel::set_id(int id) {
-	ERR_FAIL_COND_V(id < 0 || id >= VoxelLibrary::MAX_VOXEL_TYPES, Ref<Voxel>(this));
+	ERR_FAIL_COND_V(id < 0 || (unsigned int)id >= VoxelLibrary::MAX_VOXEL_TYPES, Ref<Voxel>(this));
 	// Cannot modify ID after creation
 	ERR_FAIL_COND_V_MSG(_id != -1, Ref<Voxel>(this), "ID cannot be modified after being added to a library");
 	_id = id;


### PR DESCRIPTION
Not sure how useful this is, but it does fix the `Wreorder`, `Wsign-compare`, and `Wparentheses` warnings that were shown while compiling (gcc). If useful, will squash before before merge. 

EDIT: there was similar previous PR: https://github.com/Zylann/godot_voxel/pull/120, as well as couple others