### PR TITLE
VoxelTerrain block_loaded, block_unloaded signals

### DIFF
--- a/doc/classes/VoxelTerrain.xml
+++ b/doc/classes/VoxelTerrain.xml
@@ -66,6 +66,26 @@
 		<member name="voxel_library" type="VoxelLibrary" setter="set_voxel_library" getter="get_voxel_library">
 		</member>
 	</members>
+	<signals>
+		<signal name="block_loaded">
+			<argument index="0" name="block_position" type="Vector3"> 
+			</argument>
+			<argument index="1" name="lod" type="int"> 
+			</argument>
+			<description>
+				Emitted when a new block is loaded from stream. Note it might be not visible yet. 
+			</description>
+		</signal>
+		<signal name="block_unloaded">
+			<argument index="0" name="block_position" type="Vector3"> 
+			</argument>
+			<argument index="1" name="lod" type="int"> 
+			</argument>
+			<description>
+				Emitted when a block unloaded due to being outside view distance.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 	</constants>
 </class>

--- a/terrain/voxel_terrain.h
+++ b/terrain/voxel_terrain.h
@@ -20,6 +20,9 @@ class VoxelTool;
 class VoxelTerrain : public Spatial {
 	GDCLASS(VoxelTerrain, Spatial)
 public:
+	static const char *SIGNAL_BLOCK_LOADED;
+	static const char *SIGNAL_BLOCK_UNLOADED;
+	
 	VoxelTerrain();
 	~VoxelTerrain();
 


### PR DESCRIPTION
WIP PR. Closes #99.

Currently working for blocky terrain, haven't touch LOD terrain yet. 
Signal `block_loaded` fires once a new block is added to map, this means that the blocks' mesh is not set yet. For my use case I just need access to the voxel data, so this works. I'm not sure what use case would require mesh to be meshed before processing freshly loaded block.