### PR TITLE
Fix binding of is_empty to allow build with mono

### DIFF
--- a/meshers/blocky/voxel.cpp
+++ b/meshers/blocky/voxel.cpp
@@ -418,7 +418,7 @@ void Voxel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_collision_mask", "mask"), &Voxel::set_collision_mask);
 	ClassDB::bind_method(D_METHOD("get_collision_mask"), &Voxel::get_collision_mask);
 
-	ClassDB::bind_method(D_METHOD("is_empty()"), &Voxel::is_empty);
+	ClassDB::bind_method(D_METHOD("is_empty"), &Voxel::is_empty);
 
 	// TODO Update to StringName in Godot 4
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "voxel_name"), "set_voxel_name", "get_voxel_name");


### PR DESCRIPTION
In order to build godot with godot_voxel and mono I had to make the change to the is_empty binding in meshers/blocky/voxel.cpp
Without this change the cs file generated during `./bin/godot.x11.tools.64.mono --generate-mono-glue modules/mono/glue` is not valid C# code.
I'm not sure if this will cause or fix a similar problem creating other bindings -- for gdscript for instance.
This is my first contribution to anything godot related, so this change is more of an educated guess than anything :)
