### PR TITLE
Fix virtual bindings to work with C#

### DIFF
--- a/doc/classes/VoxelGenerator.xml
+++ b/doc/classes/VoxelGenerator.xml
@@ -7,7 +7,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="generate_block">
+		<method name="generate_block" qualifiers="virtual">
 			<return type="void">
 			</return>
 			<argument index="0" name="out_buffer" type="VoxelBuffer">

--- a/doc/classes/VoxelStream.xml
+++ b/doc/classes/VoxelStream.xml
@@ -7,7 +7,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="emerge_block">
+		<method name="emerge_block" qualifiers="virtual">
 			<return type="void">
 			</return>
 			<argument index="0" name="out_buffer" type="VoxelBuffer">
@@ -19,13 +19,13 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_used_channels_mask" qualifiers="const">
+		<method name="get_used_channels_mask" qualifiers="const virtual">
 			<return type="int">
 			</return>
 			<description>
 			</description>
 		</method>
-		<method name="immerge_block">
+		<method name="immerge_block" qualifiers="virtual">
 			<return type="void">
 			</return>
 			<argument index="0" name="buffer" type="VoxelBuffer">

--- a/generators/voxel_generator.cpp
+++ b/generators/voxel_generator.cpp
@@ -31,6 +31,8 @@ void VoxelGenerator::_b_generate_block(Ref<VoxelBuffer> out_buffer, Vector3 orig
 
 void VoxelGenerator::_bind_methods() {
 	// Note: C++ inheriting classes don't need to re-bind these, because they are bindings that call the actual virtual methods
-
-	ClassDB::bind_method(D_METHOD("generate_block", "out_buffer", "origin_in_voxels", "lod"), &VoxelGenerator::_b_generate_block);
+	BIND_VMETHOD(MethodInfo("generate_block",
+							PropertyInfo(Variant::OBJECT, "out_buffer", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "VoxelBuffer"),
+							PropertyInfo(Variant::VECTOR3, "origin_in_voxels"),
+							PropertyInfo(Variant::INT, "lod")));
 }

--- a/streams/voxel_stream.cpp
+++ b/streams/voxel_stream.cpp
@@ -70,9 +70,14 @@ bool VoxelStream::has_script() const {
 }
 
 void VoxelStream::_bind_methods() {
-	// TODO Make these proper virtual, it confuses C# bindings
 	// Note: C++ inheriting classes don't need to re-bind these, because they are bindings that call the actual virtual methods
-	ClassDB::bind_method(D_METHOD("emerge_block", "out_buffer", "origin_in_voxels", "lod"), &VoxelStream::_emerge_block);
-	ClassDB::bind_method(D_METHOD("immerge_block", "buffer", "origin_in_voxels", "lod"), &VoxelStream::_immerge_block);
-	ClassDB::bind_method(D_METHOD("get_used_channels_mask"), &VoxelStream::_get_used_channels_mask);
+	BIND_VMETHOD(MethodInfo("emerge_block",
+							PropertyInfo(Variant::OBJECT, "out_buffer", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "VoxelBuffer"),
+							PropertyInfo(Variant::VECTOR3, "origin_in_voxels"),
+							PropertyInfo(Variant::INT, "lod")));
+	BIND_VMETHOD(MethodInfo("immerge_block",
+							PropertyInfo(Variant::OBJECT, "buffer", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "VoxelBuffer"),
+							PropertyInfo(Variant::VECTOR3, "origin_in_voxels"),
+							PropertyInfo(Variant::INT, "lod")));
+	BIND_VMETHOD(MethodInfo(Variant::INT, "get_used_channels_mask"));
 }


### PR DESCRIPTION
This makes it possible to write a custom voxel generator in C#.
I've posted an example to test with here: https://github.com/tdaffin/voxel_tools_mono

You'll have to build Godot with a patched mono runtime for this to work, because the C++ code is making a call into C# from a thread created outside of C#.  Without the patched runtime or you'll run a crash in unpatched mono. 
 For details see this PR: https://github.com/godotengine/godot/pull/42039
