### PR TITLE
Fix bindings so that generate-mono-glue for C# bindings works

### DIFF
--- a/meshers/blocky/voxel.cpp
+++ b/meshers/blocky/voxel.cpp
@@ -410,7 +410,7 @@ void Voxel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_transparent", "transparent"), &Voxel::set_transparent);
 	ClassDB::bind_method(D_METHOD("is_transparent"), &Voxel::is_transparent);
 
-	ClassDB::bind_method(D_METHOD("set_transparency_index", "transparent"), &Voxel::set_transparency_index);
+	ClassDB::bind_method(D_METHOD("set_transparency_index", "transparency_index"), &Voxel::set_transparency_index);
 	ClassDB::bind_method(D_METHOD("get_transparency_index"), &Voxel::get_transparency_index);
 
 	ClassDB::bind_method(D_METHOD("set_random_tickable", "rt"), &Voxel::set_random_tickable);

--- a/meshers/blocky/voxel.h
+++ b/meshers/blocky/voxel.h
@@ -96,7 +96,7 @@ public:
 	_FORCE_INLINE_ bool is_transparent() const { return _transparency_index != 0; }
 
 	void set_transparency_index(int i);
-	uint8_t get_transparency_index() const { return _transparency_index; }
+	int get_transparency_index() const { return _transparency_index; }
 
 	void set_custom_mesh(Ref<Mesh> mesh);
 	Ref<Mesh> get_custom_mesh() const { return _custom_mesh; }


### PR DESCRIPTION
I had to make a few changes to the latest version so that I could run
`./bin/godot.x11.opt.tools.64.mono --generate-mono-glue modules/mono/glue`
to generate the C# bindings.

Without these changes the command exits with:
```
Generating Voxel.cs...
ERROR: _generate_cs_property: Condition "getter->return_type.cname != setter->arguments.back()->get().type.cname" is true. Returned: ERR_BUG
   At: modules/mono/editor/bindings_generator.cpp:1428.
ERROR: _generate_cs_type: Failed to generate property 'transparency_index' for class 'Voxel'.
   At: modules/mono/editor/bindings_generator.cpp:1298.
ERROR: generate_cs_api: Generation of the Core API C# project failed.
   At: modules/mono/editor/bindings_generator.cpp:1114.
ERROR: handle_cmdline_args: --generate-mono-glue: Failed to generate the C# API.
   At: modules/mono/editor/bindings_generator.cpp:3182.
```
