### PR TITLE
Fix tautological-compare error

### DIFF
--- a/generators/graph/range_utility.cpp
+++ b/generators/graph/range_utility.cpp
@@ -533,10 +533,10 @@ template <typename F2, typename F3>
 void test_noise(String name, int tests, F2 noise_func_2d, F3 noise_func_3d) {
 	print_line(String("--- {0}:").format(varray(name)));
 
-	if ((tests & TEST_MIN_MAX) == 1) {
+	if (tests & TEST_MIN_MAX) {
 		test_min_max<F2, F3, double>(noise_func_2d, noise_func_3d);
 	}
-	if ((tests & TEST_DERIVATIVES) == 1) {
+	if (tests & TEST_DERIVATIVES) {
 		test_derivatives_tpl<F2, F3, double>(noise_func_2d, noise_func_3d);
 		test_derivatives_with_image(name + "_3D", 10, noise_func_3d);
 	}


### PR DESCRIPTION
Comparing the bitwise 'and' result and a number inside the if in this way results always false unless the bitwise 'and' result is 1.

If the intended use of the variable `tests` is as bitflags, then it's wrong to compare the different results to the same integer number since the bitwise & operation can return at most 0 or the bitmask. This triggered a compiler error when compiled with -werror=yes (and curiously this was not triggered in the CI despite the compile command including that flag)