### PR TITLE
Fix instance generator using wrong height for filtering

### DIFF
--- a/terrain/instancing/voxel_instance_generator.cpp
+++ b/terrain/instancing/voxel_instance_generator.cpp
@@ -257,7 +257,7 @@ void VoxelInstanceGenerator::generate_transforms(
 		}
 
 		if (height_filter) {
-			float y = t.origin.y;
+			float y = block_local_transform.origin.y + t.origin.y;
 			if (up_mode == UP_MODE_SPHERE) {
 				if (!sphere_distance_is_computed) {
 					sphere_distance = (block_local_transform.origin + t.origin).length();


### PR DESCRIPTION
The instance generator was using the y position relative to the block when checking if the instance is within the min_height and max_height range. I fixed it by having use the y position relative to the terrain for filtering instead.