### PR TITLE
Added shadow mode setting to VoxelInstanceLibraryItems

### DIFF
--- a/doc/classes/VoxelInstanceLibraryItem.xml
+++ b/doc/classes/VoxelInstanceLibraryItem.xml
@@ -50,6 +50,8 @@
 		</method>
 	</methods>
 	<members>
+		<member name="cast_shadow" type="int" setter="set_cast_shadows_setting" getter="get_cast_shadows_setting" enum="VisualServer.ShadowCastingSetting" default="1">
+		</member>
 		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer" default="1">
 		</member>
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">

--- a/terrain/instancing/voxel_instance_library_item.cpp
+++ b/terrain/instancing/voxel_instance_library_item.cpp
@@ -287,9 +287,4 @@ void VoxelInstanceLibraryItem::_bind_methods() {
 			"set_collision_mask", "get_collision_mask");
 
 	BIND_CONSTANT(MAX_MESH_LODS);
-
-	BIND_ENUM_CONSTANT(VisualServer::SHADOW_CASTING_SETTING_OFF);
-	BIND_ENUM_CONSTANT(VisualServer::SHADOW_CASTING_SETTING_ON);
-	BIND_ENUM_CONSTANT(VisualServer::SHADOW_CASTING_SETTING_DOUBLE_SIDED);
-	BIND_ENUM_CONSTANT(VisualServer::SHADOW_CASTING_SETTING_SHADOWS_ONLY);
 }

--- a/terrain/instancing/voxel_instance_library_item.cpp
+++ b/terrain/instancing/voxel_instance_library_item.cpp
@@ -94,6 +94,18 @@ Ref<Material> VoxelInstanceLibraryItem::get_material_override() const {
 	return _material_override;
 }
 
+void VoxelInstanceLibraryItem::set_cast_shadows_setting(VisualServer::ShadowCastingSetting mode) {
+	if (mode == _shadow_casting_setting) {
+		return;
+	}
+	_shadow_casting_setting = mode;
+	notify_listeners(CHANGE_VISUAL);
+}
+
+VisualServer::ShadowCastingSetting VoxelInstanceLibraryItem::get_cast_shadows_setting() const {
+	return _shadow_casting_setting;
+}
+
 void VoxelInstanceLibraryItem::set_collision_layer(int collision_layer) {
 	_collision_layer = collision_layer;
 }
@@ -228,6 +240,10 @@ void VoxelInstanceLibraryItem::_bind_methods() {
 			&VoxelInstanceLibraryItem::set_material_override);
 	ClassDB::bind_method(D_METHOD("get_material_override"), &VoxelInstanceLibraryItem::get_material_override);
 
+	ClassDB::bind_method(D_METHOD("set_cast_shadows_setting", "mode"),
+			&VoxelInstanceLibraryItem::set_cast_shadows_setting);
+	ClassDB::bind_method(D_METHOD("get_cast_shadows_setting"), &VoxelInstanceLibraryItem::get_cast_shadows_setting);
+
 	ClassDB::bind_method(D_METHOD("set_collision_layer", "collision_layer"),
 			&VoxelInstanceLibraryItem::set_collision_layer);
 	ClassDB::bind_method(D_METHOD("get_collision_layer"), &VoxelInstanceLibraryItem::get_collision_layer);
@@ -263,10 +279,17 @@ void VoxelInstanceLibraryItem::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material_override", PROPERTY_HINT_RESOURCE_TYPE, "Material"),
 			"set_material_override", "get_material_override");
 
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "cast_shadow", PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only"), "set_cast_shadows_setting", "get_cast_shadows_setting");
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_3D_PHYSICS),
 			"set_collision_layer", "get_collision_layer");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS),
 			"set_collision_mask", "get_collision_mask");
 
 	BIND_CONSTANT(MAX_MESH_LODS);
+
+	BIND_ENUM_CONSTANT(VisualServer::SHADOW_CASTING_SETTING_OFF);
+	BIND_ENUM_CONSTANT(VisualServer::SHADOW_CASTING_SETTING_ON);
+	BIND_ENUM_CONSTANT(VisualServer::SHADOW_CASTING_SETTING_DOUBLE_SIDED);
+	BIND_ENUM_CONSTANT(VisualServer::SHADOW_CASTING_SETTING_SHADOWS_ONLY);
 }

--- a/terrain/instancing/voxel_instance_library_item.h
+++ b/terrain/instancing/voxel_instance_library_item.h
@@ -51,6 +51,9 @@ public:
 	void set_material_override(Ref<Material> material);
 	Ref<Material> get_material_override() const;
 
+	void set_cast_shadows_setting(VisualServer::ShadowCastingSetting mode);
+	VisualServer::ShadowCastingSetting get_cast_shadows_setting() const;
+
 	void set_collision_layer(int collision_layer);
 	int get_collision_layer() const;
 
@@ -110,6 +113,8 @@ private:
 	// It is preferred to have materials on the mesh already,
 	// but this is in case OBJ meshes are used, which often dont have a material of their own
 	Ref<Material> _material_override;
+
+	VisualServer::ShadowCastingSetting _shadow_casting_setting = VisualServer::SHADOW_CASTING_SETTING_ON;
 
 	int _collision_mask = 1;
 	int _collision_layer = 1;

--- a/terrain/instancing/voxel_instancer.cpp
+++ b/terrain/instancing/voxel_instancer.cpp
@@ -714,6 +714,7 @@ void VoxelInstancer::update_block_from_transforms(int block_index, ArraySlice<co
 		block->multimesh_instance.set_world(world);
 		block->multimesh_instance.set_transform(block_transform);
 		block->multimesh_instance.set_material_override(item->get_material_override());
+		block->multimesh_instance.set_cast_shadows_setting(item->get_cast_shadows_setting());
 	}
 
 	// Update bodies

--- a/terrain/instancing/voxel_instancer.cpp
+++ b/terrain/instancing/voxel_instancer.cpp
@@ -436,6 +436,7 @@ void VoxelInstancer::update_layer_meshes(int layer_id) {
 			continue;
 		}
 		block->multimesh_instance.set_material_override(item->get_material_override());
+		block->multimesh_instance.set_cast_shadows_setting(item->get_cast_shadows_setting());
 		Ref<MultiMesh> multimesh = block->multimesh_instance.get_multimesh();
 		if (multimesh.is_valid()) {
 			Ref<Mesh> mesh;

--- a/util/godot/direct_multimesh_instance.cpp
+++ b/util/godot/direct_multimesh_instance.cpp
@@ -80,6 +80,12 @@ void DirectMultiMeshInstance::set_material_override(Ref<Material> material) {
 	}
 }
 
+void DirectMultiMeshInstance::set_cast_shadows_setting(VisualServer::ShadowCastingSetting mode) {
+	ERR_FAIL_COND(!_multimesh_instance.is_valid());
+	VisualServer &vs = *VisualServer::get_singleton();
+	vs.instance_geometry_set_cast_shadows_setting(_multimesh_instance, mode);
+}
+
 PoolRealArray DirectMultiMeshInstance::make_transform_3d_bulk_array(ArraySlice<const Transform> transforms) {
 	VOXEL_PROFILE_SCOPE();
 

--- a/util/godot/direct_multimesh_instance.h
+++ b/util/godot/direct_multimesh_instance.h
@@ -23,6 +23,7 @@ public:
 	void set_transform(Transform world_transform);
 	void set_visible(bool visible);
 	void set_material_override(Ref<Material> material);
+	void set_cast_shadows_setting(VisualServer::ShadowCastingSetting mode);
 
 	static PoolRealArray make_transform_3d_bulk_array(ArraySlice<const Transform> transforms);
 


### PR DESCRIPTION
This adds the cast_shadow property to DirectMultiMeshInstance and VoxelInstanceLibraryItem. This allows for instance items to have their shadow mode set from the editor but you still need to regenerate the terrain to see the difference.