### PR TITLE
Added Mono builds in a new Github Actions workflow

### DIFF
--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -1,4 +1,4 @@
-name: Mono Builds
+name: 🐒 Mono Builds
 on:
   push:
     branches: [ master, github_actions ]

--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -1,0 +1,257 @@
+name: Mono Builds
+on:
+  push:
+    branches: [ master, github_actions ]
+  pull_request:
+    branches: [ master ]
+
+# Global Cache Settings
+env:
+  GODOT_BASE_BRANCH: 3.x
+  SCONS_CACHE_LIMIT: 4096
+
+jobs:
+
+  mono-glue:
+    runs-on: "ubuntu-20.04"
+    name: Generate Mono Glue
+
+    steps:
+      # Clone Godot
+      - uses: actions/checkout@v2
+        with:
+          repository: godotengine/godot
+          ref: 3.x
+
+      # Clone our module under the correct directory
+      - uses: actions/checkout@v2
+        with:
+          path: modules/voxel
+
+      # Azure repositories are not reliable, we need to prevent azure giving us packages.
+      - name: Make apt sources.list use the default Ubuntu repositories
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/*
+          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+          sudo apt-get update
+
+      # Install all packages (except scons)
+      - name: Configure dependencies
+        run: |
+          sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev xvfb \
+            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
+
+      # Upload cache on completion and check it out now
+      - name: Load .scons_cache directory
+        id: mono-glue-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{github.workspace}}/.scons_cache/
+          key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
+
+      # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          # Semantic version range syntax or exact version of a Python version
+          python-version: '3.x'
+          # Optional - x64 or x86 architecture, defaults to x64
+          architecture: 'x64'
+
+      # Setup scons, print python version and scons version info, so if anything is broken it won't run the build.
+      - name: Configuring Python packages
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -m pip install scons
+          python --version
+          scons --version
+
+      # We should always be explicit with our flags usage here since it's gonna be sure to always set those flags
+      - name: Compile Godot (module_mono_enabled=yes mono_glue=no)
+        env:
+          SCONS_CACHE: ${{github.workspace}}/.scons_cache/
+        run: |
+          scons -j2 verbose=yes warnings=all werror=yes platform=linuxbsd tools=yes tests=no target=release_debug debug_symbols=no module_mono_enabled=yes mono_glue=no copy_mono_root=yes
+
+      - name: Generate Mono Glue
+        run: |
+          xvfb-run ./bin/godot.x11.opt.tools.64.mono --generate-mono-glue modules/mono/glue || true
+
+      # Make glue available as artifact for dependent jobs
+      - uses: actions/upload-artifact@v2
+        with:
+          name: mono-glue
+          path: |
+            modules/mono/glue/**.gen.*
+            modules/mono/glue/GodotSharp/GodotSharp/Generated/
+            modules/mono/glue/GodotSharp/GodotSharpEditor/Generated/
+
+  linux-editor-mono:
+    runs-on: "ubuntu-20.04"
+    name: Linux Editor w/ Mono
+    needs: mono-glue
+
+    steps:
+      # Clone Godot
+      - uses: actions/checkout@v2
+        with:
+          repository: godotengine/godot
+          ref: 3.x
+
+      # Clone our module under the correct directory
+      - uses: actions/checkout@v2
+        with:
+          path: modules/voxel
+
+      # Azure repositories are not reliable, we need to prevent azure giving us packages.
+      - name: Make apt sources.list use the default Ubuntu repositories
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/*
+          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+          sudo apt-get update
+
+      # Install all packages (except scons)
+      - name: Configure dependencies
+        run: |
+          sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
+            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
+
+      # Upload cache on completion and check it out now
+      - name: Load .scons_cache directory
+        id: linux-editor-mono-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{github.workspace}}/.scons_cache/
+          key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
+
+      # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          # Semantic version range syntax or exact version of a Python version
+          python-version: '3.x'
+          # Optional - x64 or x86 architecture, defaults to x64
+          architecture: 'x64'
+
+      # Setup scons, print python version and scons version info, so if anything is broken it won't run the build.
+      - name: Configuring Python packages
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -m pip install scons
+          python --version
+          scons --version
+
+      # Download glue from the mono-glue job
+      - name: Download Glue
+        uses: actions/download-artifact@v2
+        with:
+          name: mono-glue
+          path: modules/mono/glue
+
+      # We should always be explicit with our flags usage here since it's gonna be sure to always set those flags
+      - name: Compilation
+        env:
+          SCONS_CACHE: ${{github.workspace}}/.scons_cache/
+        run: |
+          scons -j2 verbose=yes warnings=all werror=yes platform=linuxbsd tools=yes tests=no target=release_debug debug_symbols=no module_mono_enabled=yes mono_glue=yes mono_static=yes copy_mono_root=yes
+
+      # TODO Such tests are able to run from Godot 4.0 only
+      # Execute unit tests for the editor
+      #- name: Unit Tests
+      #  run: |
+      #    ./bin/godot.linuxbsd.opt.tools.64.mono --test
+
+      # Make build available
+      - uses: actions/upload-artifact@v2
+        with:
+          name: godot.x11.opt.tools.64.mono
+          path: bin/*
+
+
+  windows-editor-mono:
+    # Windows 10 with latest image
+    runs-on: "windows-latest"
+    name: Windows Editor w/ Mono
+    needs: mono-glue
+
+    steps:
+      # Clone Godot
+      - uses: actions/checkout@v2
+        with:
+          repository: godotengine/godot
+          ref: 3.x
+
+      # Clone our module under the correct directory
+      - uses: actions/checkout@v2
+        with:
+          path: modules/voxel
+
+      # Install mono
+      - name: Configure dependencies
+        run: |
+          choco install -y mono
+
+      # Upload cache on completion and check it out now
+      # Editing this is pretty dangerous for Windows since it can break and needs to be properly tested with a fresh cache.
+      - name: Load .scons_cache directory
+        id: windows-editor-mono-cache
+        uses: actions/cache@v2
+        with:
+          path: /.scons_cache/
+          key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
+
+      # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          # Semantic version range syntax or exact version of a Python version
+          python-version: '3.x'
+          # Optional - x64 or x86 architecture, defaults to x64
+          architecture: 'x64'
+
+      # Setup scons, print python version and scons version info, so if anything is broken it won't run the build.
+      - name: Configuring Python packages
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -m pip install scons pywin32
+          python --version
+          scons --version
+
+      # Download glue from the mono-glue job
+      - name: Download Glue
+        uses: actions/download-artifact@v2
+        with:
+          name: mono-glue
+          path: modules/mono/glue
+
+      # We should always be explicit with our flags usage here since it's gonna be sure to always set those flags
+      - name: Compilation
+        env:
+          SCONS_CACHE_MSVC_CONFIG: true
+          SCONS_CACHE: /.scons_cache/
+        run: |
+          scons -j2 verbose=yes warnings=all werror=yes platform=windows tools=yes tests=no target=release_debug module_mono_enabled=yes mono_glue=yes copy_mono_root=yes mono_static=yes
+
+      # TODO Such tests are able to run from Godot 4.0 only
+      # Execute unit tests for the editor
+      #- name: Unit Tests
+      #  run: |
+      #    ./bin/godot.windows.opt.tools.64.mono.exe --test
+
+      # Make build available
+      - uses: actions/upload-artifact@v2
+        with:
+          name: godot.windows.opt.tools.64.mono.exe
+          path: bin/*

--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -175,7 +175,6 @@ jobs:
           name: godot.x11.opt.tools.64.mono
           path: bin/*
 
-
   windows-editor-mono:
     # Windows 10 with latest image
     runs-on: "windows-latest"
@@ -242,7 +241,7 @@ jobs:
           SCONS_CACHE_MSVC_CONFIG: true
           SCONS_CACHE: /.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=windows tools=yes tests=no target=release_debug module_mono_enabled=yes mono_glue=yes copy_mono_root=yes mono_static=yes
+          scons -j2 verbose=yes warnings=all werror=yes platform=windows tools=yes tests=no target=release_debug debug_symbols=no module_mono_enabled=yes mono_glue=yes copy_mono_root=yes mono_static=yes
 
       # TODO Such tests are able to run from Godot 4.0 only
       # Execute unit tests for the editor

--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -252,5 +252,5 @@ jobs:
       # Make build available
       - uses: actions/upload-artifact@v2
         with:
-          name: godot.windows.opt.tools.64.mono.exe
+          name: godot.windows.opt.tools.64.mono
           path: bin/*


### PR DESCRIPTION
This resolves #244 

I added Mono builds for Linux and Windows as a third github actions workflow. 
This works by generating the Mono glue in the first step and then sharing that glue with the Linux and 
Windows steps. This dependency is why I split it off into its own workflow because the alternative would generate the glue twice.