### PR TITLE
Added an option in VoxelInstanceGenerator for random rotation

### DIFF
--- a/terrain/instancing/voxel_instance_generator.h
+++ b/terrain/instancing/voxel_instance_generator.h
@@ -103,6 +103,9 @@ public:
 	void set_random_vertical_flip(bool flip);
 	bool get_random_vertical_flip() const;
 
+	void set_random_rotation(bool rotate);
+	bool get_random_rotation() const;
+
 	void set_noise(Ref<FastNoiseLite> noise);
 	Ref<FastNoiseLite> get_noise() const;
 
@@ -131,6 +134,7 @@ private:
 	float _min_height = std::numeric_limits<float>::min();
 	float _max_height = std::numeric_limits<float>::max();
 	bool _random_vertical_flip = false;
+	bool _random_rotation = true;
 	EmitMode _emit_mode = EMIT_FROM_VERTICES;
 	Distribution _scale_distribution = DISTRIBUTION_QUADRATIC;
 	Ref<FastNoiseLite> _noise;


### PR DESCRIPTION


https://user-images.githubusercontent.com/38600896/133188247-0db52f42-ab54-4609-b958-36b47e0890f3.mp4


This option only has a noticeable effect on non-flat terrains when vertical_alignment is 1 (as seen above), because the angle of the terrain determines rotation. This is documented in the code.