### PR TITLE
Fixed macos/clang build errors

### DIFF
--- a/editor/vox/vox_mesh_importer.cpp
+++ b/editor/vox/vox_mesh_importer.cpp
@@ -6,6 +6,7 @@
 #include "../../streams/vox_data.h"
 #include "../../util/profiling.h"
 #include "vox_import_funcs.h"
+#include "../../util/macros.h"
 
 String VoxelVoxMeshImporter::get_importer_name() const {
 	return "VoxelVoxMeshImporter";
@@ -193,7 +194,7 @@ static Ref<VoxelBuffer> make_single_voxel_grid(Span<const ModelInstance> instanc
 	const size_t volume = bounding_box.size.volume();
 	ERR_FAIL_COND_V_MSG(volume > limit, Ref<VoxelBuffer>(),
 			String("Vox data is too big to be meshed as a single mesh ({0}: {0} bytes)")
-					.format(varray(bounding_box.size.to_vec3(), volume)));
+					.format(varray(bounding_box.size.to_vec3(), SIZE_T_TO_VARIANT(volume))));
 
 	Ref<VoxelBuffer> voxels;
 	voxels.instance();

--- a/storage/voxel_memory_pool.h
+++ b/storage/voxel_memory_pool.h
@@ -34,7 +34,13 @@ private:
 	Pool *get_or_create_pool(size_t size);
 	void clear();
 
-	HashMap<size_t, Pool *> _pools;
+	struct SizeTHasher {
+		static _FORCE_INLINE_ uint32_t hash(const size_t p_int) {
+			return HashMapHasherDefault::hash(uint64_t(p_int));
+		}
+	};
+
+	HashMap<size_t, Pool *, SizeTHasher> _pools;
 	unsigned int _used_blocks = 0;
 	Mutex _mutex;
 };

--- a/streams/vox_data.cpp
+++ b/streams/vox_data.cpp
@@ -230,7 +230,7 @@ Error Data::_load_from_file(String fpath) {
 		f.get_32(); // child_chunks_size
 
 		PRINT_VERBOSE(String("Reading chunk {0} at {1}, size={2}")
-							  .format(varray(chunk_id, f.get_position(), chunk_size)));
+							  .format(varray(chunk_id, SIZE_T_TO_VARIANT(f.get_position()), chunk_size)));
 
 		if (strcmp(chunk_id, "SIZE") == 0) {
 			Vector3i size;


### PR DESCRIPTION
This fixes errors I hit building master on macos 11.5.2 with clang 12.0.5, all concerning `size_t` type conversion.

