### PR TITLE
Change portal culling mode for meshes/multimeshes

### DIFF
--- a/editor/voxel_debug.cpp
+++ b/editor/voxel_debug.cpp
@@ -118,6 +118,7 @@ public:
 		// The reason is still unknown.
 		// It should be off anyways, but it's rather concerning.
 		_mesh_instance.set_cast_shadows_setting(VisualServer::SHADOW_CASTING_SETTING_OFF);
+		_mesh_instance.set_portal_mode(VisualServer::INSTANCE_PORTAL_MODE_GLOBAL);
 	}
 
 	void set_mesh(Ref<Mesh> mesh) {

--- a/terrain/instancing/voxel_instancer.cpp
+++ b/terrain/instancing/voxel_instancer.cpp
@@ -796,6 +796,7 @@ void VoxelInstancer::update_block_from_transforms(int block_index, Span<const Tr
 			if (!block->multimesh_instance.is_valid()) {
 				block->multimesh_instance.create();
 				block->multimesh_instance.set_visible(is_visible());
+				block->multimesh_instance.set_portal_mode(VisualServer::INSTANCE_PORTAL_MODE_GLOBAL);
 			}
 			block->multimesh_instance.set_multimesh(multimesh);
 			block->multimesh_instance.set_world(world);

--- a/terrain/voxel_mesh_block.cpp
+++ b/terrain/voxel_mesh_block.cpp
@@ -61,6 +61,7 @@ void VoxelMeshBlock::set_mesh(Ref<Mesh> mesh) {
 			// Create instance if it doesn't exist
 			_mesh_instance.create();
 			set_mesh_instance_visible(_mesh_instance, _visible && _parent_visible);
+			_mesh_instance.set_portal_mode(VisualServer::INSTANCE_PORTAL_MODE_GLOBAL);
 		}
 
 		_mesh_instance.set_mesh(mesh);
@@ -95,6 +96,7 @@ void VoxelMeshBlock::set_transition_mesh(Ref<Mesh> mesh, int side) {
 			// Create instance if it doesn't exist
 			mesh_instance.create();
 			set_mesh_instance_visible(mesh_instance, _visible && _parent_visible && _is_transition_visible(side));
+			mesh_instance.set_portal_mode(VisualServer::INSTANCE_PORTAL_MODE_GLOBAL);
 		}
 
 		mesh_instance.set_mesh(mesh);

--- a/util/godot/direct_mesh_instance.cpp
+++ b/util/godot/direct_mesh_instance.cpp
@@ -81,6 +81,12 @@ void DirectMeshInstance::set_cast_shadows_setting(VisualServer::ShadowCastingSet
 	vs.instance_geometry_set_cast_shadows_setting(_mesh_instance, mode);
 }
 
+void DirectMeshInstance::set_portal_mode(VisualServer::InstancePortalMode mode) {
+	ERR_FAIL_COND(!_mesh_instance.is_valid());
+	VisualServer &vs = *VisualServer::get_singleton();
+	vs.instance_set_portal_mode(_mesh_instance, mode);
+}
+
 Ref<Mesh> DirectMeshInstance::get_mesh() const {
 	return _mesh;
 }

--- a/util/godot/direct_mesh_instance.h
+++ b/util/godot/direct_mesh_instance.h
@@ -21,6 +21,7 @@ public:
 	void set_material_override(Ref<Material> material);
 	void set_visible(bool visible);
 	void set_cast_shadows_setting(VisualServer::ShadowCastingSetting mode);
+	void set_portal_mode(VisualServer::InstancePortalMode mode);
 
 	Ref<Mesh> get_mesh() const;
 

--- a/util/godot/direct_multimesh_instance.cpp
+++ b/util/godot/direct_multimesh_instance.cpp
@@ -86,6 +86,13 @@ void DirectMultiMeshInstance::set_cast_shadows_setting(VisualServer::ShadowCasti
 	vs.instance_geometry_set_cast_shadows_setting(_multimesh_instance, mode);
 }
 
+
+void DirectMultiMeshInstance::set_portal_mode(VisualServer::InstancePortalMode mode) {
+	ERR_FAIL_COND(!_multimesh_instance.is_valid());
+	VisualServer &vs = *VisualServer::get_singleton();
+	vs.instance_set_portal_mode(_multimesh_instance, mode);
+}
+
 inline void write_bulk_array_transform(float *dst, const Transform &t) {
 	dst[0] = t.basis.elements[0].x;
 	dst[1] = t.basis.elements[0].y;

--- a/util/godot/direct_multimesh_instance.h
+++ b/util/godot/direct_multimesh_instance.h
@@ -25,6 +25,7 @@ public:
 	void set_visible(bool visible);
 	void set_material_override(Ref<Material> material);
 	void set_cast_shadows_setting(VisualServer::ShadowCastingSetting mode);
+	void set_portal_mode(VisualServer::InstancePortalMode mode);
 
 	static void make_transform_3d_bulk_array(Span<const Transform> transforms, PoolRealArray &bulk_array);
 


### PR DESCRIPTION
Use GLOBAL mode for direct_mesh_instance/direct_multimesh_instance
so that they are visible but not culled.