### PR TITLE
Use reference counted FileAccess and DirAccess

### DIFF
--- a/edition/voxel_tool_lod_terrain.cpp
+++ b/edition/voxel_tool_lod_terrain.cpp
@@ -659,12 +659,10 @@ Array separate_floating_chunks(VoxelTool &voxel_tool, Box3i world_box, Node *par
 			// 	peer.instance();
 			// 	serializer->serialize(peer, info.voxels, false);
 			// 	String fpath = String("debug_data/split_dump_{0}.bin").format(varray(instance_index));
-			// 	FileAccess *f = FileAccess::open(fpath, FileAccess::WRITE);
+			// 	Ref<FileAccess> f = FileAccess::open(fpath, FileAccess::WRITE);
 			// 	PoolByteArray bytes = peer->get_data_array();
 			// 	PoolByteArray::Read bytes_read = bytes.read();
 			// 	f->store_buffer(bytes_read.ptr(), bytes.size());
-			// 	f->close();
-			// 	memdelete(f);
 			// }
 
 			// TODO Option to make multiple convex shapes

--- a/editor/vox/vox_scene_importer.cpp
+++ b/editor/vox/vox_scene_importer.cpp
@@ -154,7 +154,7 @@ static Error process_scene_node_recursively(const Data &data, int node_id, Node3
 		bool p_mipmaps, int p_texture_flags, bool p_streamable,
 		bool p_detect_3d, bool p_detect_srgb) {
 	//
-	FileAccess *f = FileAccess::open(p_to_path, FileAccess::WRITE);
+	Ref<FileAccess> f = FileAccess::open(p_to_path, FileAccess::WRITE);
 	ERR_FAIL_NULL_V(f, ERR_CANT_OPEN);
 	f->store_8('G');
 	f->store_8('D');
@@ -223,7 +223,6 @@ static Error process_scene_node_recursively(const Data &data, int node_id, Node3
 		f->store_buffer(r.ptr(), data_len);
 	}
 
-	memdelete(f);
 	return OK;
 }*/
 

--- a/generators/graph/program_graph.cpp
+++ b/generators/graph/program_graph.cpp
@@ -340,8 +340,8 @@ void ProgramGraph::debug_print_dot_file(String file_path) const {
 	// https://www.graphviz.org/pdf/dotguide.pdf
 
 	Error err;
-	FileAccess *f = FileAccess::open(file_path, FileAccess::WRITE, &err);
-	if (f == nullptr) {
+	Ref<FileAccess> f = FileAccess::open(file_path, FileAccess::WRITE, &err);
+	if (f.is_null()) {
 		ERR_PRINT(String("Could not write ProgramGraph debug file as {0}: error {1}").format(varray(file_path, err)));
 		return;
 	}
@@ -363,9 +363,6 @@ void ProgramGraph::debug_print_dot_file(String file_path) const {
 	}
 
 	f->store_line("}");
-
-	f->close();
-	memdelete(f);
 }
 
 void ProgramGraph::copy_from(const ProgramGraph &other, bool copy_subresources) {

--- a/streams/file_utils.cpp
+++ b/streams/file_utils.cpp
@@ -26,7 +26,7 @@ const char *to_string(FileResult res) {
 }
 
 FileResult check_magic_and_version(
-		FileAccess *f, uint8_t expected_version, const char *expected_magic, uint8_t &out_version) {
+		Ref<FileAccess> f, uint8_t expected_version, const char *expected_magic, uint8_t &out_version) {
 	uint8_t magic[5] = { '\0' };
 	int count = f->get_buffer(magic, 4);
 	if (count != 4) {
@@ -47,9 +47,9 @@ FileResult check_magic_and_version(
 }
 
 Error check_directory_created(const String &directory_path) {
-	DirAccess *d = DirAccess::create_for_path(directory_path);
+	Ref<DirAccess> d = DirAccess::create_for_path(directory_path);
 
-	if (d == nullptr) {
+	if (d.is_null()) {
 		ERR_PRINT("Could not access to filesystem");
 		return ERR_FILE_CANT_OPEN;
 	}
@@ -59,12 +59,10 @@ Error check_directory_created(const String &directory_path) {
 		Error err = d->make_dir_recursive(directory_path);
 		if (err != OK) {
 			ERR_PRINT("Could not create directory");
-			memdelete(d);
 			return err;
 		}
 	}
 
-	memdelete(d);
 	return OK;
 }
 
@@ -80,7 +78,7 @@ Error check_directory_created_using_file_locker(const String &directory_path) {
 // Makes the file bigger to move the half from the current position further,
 // so that it makes room for the specified amount of bytes.
 // The new allocated "free" bytes have undefined values, which may be later overwritten by the caller anyways.
-void insert_bytes(FileAccess *f, size_t count, size_t temp_chunk_size) {
+void insert_bytes(Ref<FileAccess> f, size_t count, size_t temp_chunk_size) {
 	CRASH_COND(f == nullptr);
 	CRASH_COND(temp_chunk_size == 0);
 

--- a/streams/file_utils.h
+++ b/streams/file_utils.h
@@ -7,7 +7,7 @@
 
 namespace zylann {
 
-inline Vector3i get_vec3u8(FileAccess *f) {
+inline Vector3i get_vec3u8(Ref<FileAccess> f) {
 	Vector3i v;
 	v.x = f->get_8();
 	v.y = f->get_8();
@@ -15,13 +15,13 @@ inline Vector3i get_vec3u8(FileAccess *f) {
 	return v;
 }
 
-inline void store_vec3u8(FileAccess *f, const Vector3i v) {
+inline void store_vec3u8(Ref<FileAccess> f, const Vector3i v) {
 	f->store_8(v.x);
 	f->store_8(v.y);
 	f->store_8(v.z);
 }
 
-inline Vector3i get_vec3u32(FileAccess *f) {
+inline Vector3i get_vec3u32(Ref<FileAccess> f) {
 	Vector3i v;
 	v.x = f->get_32();
 	v.y = f->get_32();
@@ -29,7 +29,7 @@ inline Vector3i get_vec3u32(FileAccess *f) {
 	return v;
 }
 
-inline void store_vec3u32(FileAccess *f, const Vector3i v) {
+inline void store_vec3u32(Ref<FileAccess> f, const Vector3i v) {
 	f->store_32(v.x);
 	f->store_32(v.y);
 	f->store_32(v.z);
@@ -47,14 +47,14 @@ enum FileResult {
 
 const char *to_string(FileResult res);
 FileResult check_magic_and_version(
-		FileAccess *f, uint8_t expected_version, const char *expected_magic, uint8_t &out_version);
+		Ref<FileAccess> f, uint8_t expected_version, const char *expected_magic, uint8_t &out_version);
 
 namespace voxel {
 // Specific to voxel because it uses a global lock found only in VoxelServer
 Error check_directory_created_using_file_locker(const String &directory_path);
 } // namespace voxel
 
-void insert_bytes(FileAccess *f, size_t count, size_t temp_chunk_size = 512);
+void insert_bytes(Ref<FileAccess> f, size_t count, size_t temp_chunk_size = 512);
 
 } // namespace zylann
 

--- a/streams/region/region_file.cpp
+++ b/streams/region/region_file.cpp
@@ -64,8 +64,8 @@ static uint32_t get_header_size_v3(const RegionFormat &format) {
 }
 
 static bool save_header(
-		FileAccess *f, uint8_t version, const RegionFormat &format, const std::vector<RegionBlockInfo> &block_infos) {
-	ERR_FAIL_COND_V(f == nullptr, false);
+		Ref<FileAccess> f, uint8_t version, const RegionFormat &format, const std::vector<RegionBlockInfo> &block_infos) {
+	ERR_FAIL_COND_V(f.is_null(), false);
 
 	f->seek(0);
 
@@ -110,8 +110,8 @@ static bool save_header(
 }
 
 static bool load_header(
-		FileAccess *f, uint8_t &out_version, RegionFormat &out_format, std::vector<RegionBlockInfo> &out_block_infos) {
-	ERR_FAIL_COND_V(f == nullptr, false);
+		Ref<FileAccess> f, uint8_t &out_version, RegionFormat &out_format, std::vector<RegionBlockInfo> &out_block_infos) {
+	ERR_FAIL_COND_V(f.is_null(), false);
 
 	ERR_FAIL_COND_V(f->get_position() != 0, false);
 	ERR_FAIL_COND_V(f->get_length() < MAGIC_AND_VERSION_SIZE, false);
@@ -192,7 +192,7 @@ Error RegionFile::open(const String &fpath, bool create_if_not_found) {
 	Error file_error;
 	// Open existing file for read and write permissions. This should not create the file if it doesn't exist.
 	// Note, there is no read-only mode supported, because there was no need for it yet.
-	FileAccess *f = FileAccess::open(fpath, FileAccess::READ_WRITE, &file_error);
+	Ref<FileAccess> f = FileAccess::open(fpath, FileAccess::READ_WRITE, &file_error);
 	if (file_error != OK) {
 		if (create_if_not_found) {
 			CRASH_COND(f != nullptr);
@@ -219,7 +219,6 @@ Error RegionFile::open(const String &fpath, bool create_if_not_found) {
 	} else {
 		const Error header_error = load_header(f);
 		if (header_error != OK) {
-			memdelete(f);
 			return header_error;
 		}
 	}
@@ -279,8 +278,6 @@ Error RegionFile::close() {
 				err = ERR_FILE_CANT_WRITE;
 			}
 		}
-		memdelete(_file_access);
-		_file_access = nullptr;
 	}
 	_sectors.clear();
 	return err;
@@ -316,7 +313,7 @@ bool RegionFile::is_valid_block_position(const Vector3 position) const {
 
 Error RegionFile::load_block(Vector3i position, VoxelBufferInternal &out_block) {
 	ERR_FAIL_COND_V(_file_access == nullptr, ERR_FILE_CANT_READ);
-	FileAccess *f = _file_access;
+	Ref<FileAccess> f = _file_access;
 
 	ERR_FAIL_COND_V(!is_valid_block_position(position), ERR_INVALID_PARAMETER);
 	const unsigned int lut_index = get_block_index_in_header(position);
@@ -352,7 +349,7 @@ Error RegionFile::save_block(Vector3i position, VoxelBufferInternal &block) {
 	ERR_FAIL_COND_V(!is_valid_block_position(position), ERR_INVALID_PARAMETER);
 
 	ERR_FAIL_COND_V(_file_access == nullptr, ERR_FILE_CANT_WRITE);
-	FileAccess *f = _file_access;
+	Ref<FileAccess> f = _file_access;
 
 	// We should be allowed to migrate before write operations
 	if (_header.version != FORMAT_VERSION) {
@@ -462,7 +459,7 @@ Error RegionFile::save_block(Vector3i position, VoxelBufferInternal &block) {
 	return OK;
 }
 
-void RegionFile::pad_to_sector_size(FileAccess *f) {
+void RegionFile::pad_to_sector_size(Ref<FileAccess> f)  {
 	int rpos = f->get_position() - _blocks_begin_offset;
 	if (rpos == 0) {
 		return;
@@ -485,7 +482,7 @@ void RegionFile::remove_sectors_from_block(Vector3i block_pos, unsigned int p_se
 	CRASH_COND(_file_access == nullptr);
 	CRASH_COND(p_sector_count <= 0);
 
-	FileAccess *f = _file_access;
+	Ref<FileAccess> f = _file_access;
 	const unsigned int sector_size = _header.format.sector_size;
 	const unsigned int old_end_offset = _blocks_begin_offset + _sectors.size() * sector_size;
 
@@ -549,7 +546,7 @@ void RegionFile::remove_sectors_from_block(Vector3i block_pos, unsigned int p_se
 	}
 }
 
-bool RegionFile::save_header(FileAccess *f) {
+bool RegionFile::save_header(Ref<FileAccess> f) {
 	// We should be allowed to migrate before write operations.
 	if (_header.version != FORMAT_VERSION) {
 		ERR_FAIL_COND_V(migrate_to_latest(f) == false, false);
@@ -560,7 +557,7 @@ bool RegionFile::save_header(FileAccess *f) {
 	return true;
 }
 
-bool RegionFile::migrate_from_v2_to_v3(FileAccess *f, RegionFormat &format) {
+bool RegionFile::migrate_from_v2_to_v3(Ref<FileAccess> f,  RegionFormat &format) {
 	ZN_PRINT_VERBOSE(zylann::format("Migrating region file {} from v2 to v3", _file_path));
 
 	// We can migrate if we know in advance what format the file should contain.
@@ -586,7 +583,7 @@ bool RegionFile::migrate_from_v2_to_v3(FileAccess *f, RegionFormat &format) {
 	return save_header(f);
 }
 
-bool RegionFile::migrate_to_latest(FileAccess *f) {
+bool RegionFile::migrate_to_latest(Ref<FileAccess> f) {
 	ERR_FAIL_COND_V(f == nullptr, false);
 	ERR_FAIL_COND_V(_file_path.is_empty(), false);
 
@@ -613,7 +610,7 @@ bool RegionFile::migrate_to_latest(FileAccess *f) {
 	return true;
 }
 
-Error RegionFile::load_header(FileAccess *f) {
+Error RegionFile::load_header(Ref<FileAccess> f) {
 	ERR_FAIL_COND_V(!zylann::voxel::load_header(f, _header.version, _header.format, _header.blocks), ERR_PARSE_ERROR);
 	_blocks_begin_offset = f->get_position();
 	return OK;
@@ -653,7 +650,7 @@ bool RegionFile::has_block(unsigned int index) const {
 void RegionFile::debug_check() {
 	ERR_FAIL_COND(!is_open());
 	ERR_FAIL_COND(_file_access == nullptr);
-	FileAccess *f = _file_access;
+	Ref<FileAccess> f = _file_access;
 	const size_t file_len = f->get_length();
 
 	for (unsigned int lut_index = 0; lut_index < _header.blocks.size(); ++lut_index) {

--- a/streams/region/region_file.h
+++ b/streams/region/region_file.h
@@ -97,17 +97,17 @@ public:
 	bool is_valid_block_position(const Vector3 position) const;
 
 private:
-	bool save_header(FileAccess *f);
-	Error load_header(FileAccess *f);
+	bool save_header(Ref<FileAccess> f);
+	Error load_header(Ref<FileAccess> f);
 
 	unsigned int get_block_index_in_header(const Vector3i &rpos) const;
 	uint32_t get_sector_count_from_bytes(uint32_t size_in_bytes) const;
 
-	void pad_to_sector_size(FileAccess *f);
+	void pad_to_sector_size(Ref<FileAccess> f);
 	void remove_sectors_from_block(Vector3i block_pos, unsigned int p_sector_count);
 
-	bool migrate_to_latest(FileAccess *f);
-	bool migrate_from_v2_to_v3(FileAccess *f, RegionFormat &format);
+	bool migrate_to_latest(Ref<FileAccess> f);
+	bool migrate_from_v2_to_v3(Ref<FileAccess> f, RegionFormat &format);
 
 	struct Header {
 		uint8_t version = -1;
@@ -118,7 +118,7 @@ private:
 		std::vector<RegionBlockInfo> blocks;
 	};
 
-	FileAccess *_file_access = nullptr;
+	Ref<FileAccess> _file_access = nullptr;
 	bool _header_modified = false;
 
 	Header _header;

--- a/streams/region/voxel_stream_region_files.cpp
+++ b/streams/region/voxel_stream_region_files.cpp
@@ -292,8 +292,8 @@ FileResult VoxelStreamRegionFiles::save_meta() {
 
 	Error err;
 	VoxelFileLockerWrite file_wlock(meta_path);
-	FileAccessRef f = FileAccess::open(meta_path, FileAccess::WRITE, &err);
-	if (!f) {
+	Ref<FileAccess> f = FileAccess::open(meta_path, FileAccess::WRITE, &err);
+	if (f.is_null()) {
 		ERR_PRINT(String("Could not save {0}").format(varray(meta_path)));
 		return FILE_CANT_OPEN;
 	}
@@ -339,8 +339,8 @@ FileResult VoxelStreamRegionFiles::load_meta() {
 	{
 		Error err;
 		VoxelFileLockerRead file_rlock(meta_path);
-		FileAccessRef f = FileAccess::open(meta_path, FileAccess::READ, &err);
-		if (!f) {
+		Ref<FileAccess> f = FileAccess::open(meta_path, FileAccess::READ, &err);
+		if (f.is_null()) {
 			return FILE_CANT_OPEN;
 		}
 		json_string = f->get_as_utf8_string();
@@ -571,8 +571,8 @@ void VoxelStreamRegionFiles::_convert_files(Meta new_meta) {
 
 	// Backup current folder by renaming it, leaving the current name vacant
 	{
-		DirAccessRef da = DirAccess::create_for_path(_directory_path);
-		ERR_FAIL_COND(!da);
+		Ref<DirAccess> da = DirAccess::create_for_path(_directory_path);
+		ERR_FAIL_COND(da.is_null());
 		int i = 0;
 		String old_dir;
 		while (true) {
@@ -613,8 +613,8 @@ void VoxelStreamRegionFiles::_convert_files(Meta new_meta) {
 					old_stream->_directory_path.plus_file("regions").plus_file("lod") + String::num_int64(lod);
 			const String ext = String(".") + RegionFormat::FILE_EXTENSION;
 
-			DirAccessRef da = DirAccess::open(lod_folder);
-			if (!da) {
+			Ref<DirAccess> da = DirAccess::open(lod_folder);
+			if (da.is_null()) {
 				continue;
 			}
 

--- a/streams/vox_data.cpp
+++ b/streams/vox_data.cpp
@@ -48,8 +48,8 @@ uint32_t g_default_palette[PALETTE_SIZE] = {
 };
 // clang-format on
 
-static Error parse_string(FileAccess &f, String &s) {
-	const int size = f.get_32();
+static Error parse_string(Ref<FileAccess> f, String &s) {
+	const int size = f->get_32();
 
 	// Sanity checks
 	ERR_FAIL_COND_V(size < 0, ERR_INVALID_DATA);
@@ -57,7 +57,7 @@ static Error parse_string(FileAccess &f, String &s) {
 
 	static thread_local std::vector<char> bytes;
 	bytes.resize(size);
-	ERR_FAIL_COND_V(f.get_buffer((uint8_t *)bytes.data(), bytes.size()) != bytes.size(), ERR_PARSE_ERROR);
+	ERR_FAIL_COND_V(f->get_buffer((uint8_t *)bytes.data(), bytes.size()) != bytes.size(), ERR_PARSE_ERROR);
 
 	s.clear();
 	ERR_FAIL_COND_V(s.parse_utf8(bytes.data(), bytes.size()), ERR_PARSE_ERROR);
@@ -65,8 +65,8 @@ static Error parse_string(FileAccess &f, String &s) {
 	return OK;
 }
 
-static Error parse_dictionary(FileAccess &f, std::unordered_map<String, String> &dict) {
-	const int item_count = f.get_32();
+static Error parse_dictionary(Ref<FileAccess> f, std::unordered_map<String, String> &dict) {
+	const int item_count = f->get_32();
 
 	// Sanity checks
 	ERR_FAIL_COND_V(item_count < 0, ERR_INVALID_DATA);
@@ -163,9 +163,9 @@ static Basis parse_basis(uint8_t data) {
 }
 
 Error parse_node_common_header(
-		Node &node, FileAccess &f, const std::unordered_map<int, std::unique_ptr<Node>> &scene_graph) {
+		Node &node, Ref<FileAccess> f, const std::unordered_map<int, std::unique_ptr<Node>> &scene_graph) {
 	//
-	const int node_id = f.get_32();
+	const int node_id = f->get_32();
 	ERR_FAIL_COND_V_MSG(scene_graph.find(node_id) != scene_graph.end(), ERR_INVALID_DATA,
 			String("Node with ID {0} already exists").format(varray(node_id)));
 
@@ -203,39 +203,38 @@ Error Data::_load_from_file(String fpath) {
 	ZN_PRINT_VERBOSE(format("Loading {}", fpath));
 
 	Error open_err;
-	FileAccessRef f_ref = FileAccess::open(fpath, FileAccess::READ, &open_err);
-	if (f_ref == nullptr) {
+	Ref<FileAccess> f = FileAccess::open(fpath, FileAccess::READ, &open_err);
+	if (f.is_null()) {
 		return open_err;
 	}
-	FileAccess &f = *f_ref;
 
 	char magic[5] = { 0 };
-	ERR_FAIL_COND_V(f.get_buffer((uint8_t *)magic, 4) != 4, ERR_PARSE_ERROR);
+	ERR_FAIL_COND_V(f->get_buffer((uint8_t *)magic, 4) != 4, ERR_PARSE_ERROR);
 	ERR_FAIL_COND_V(strcmp(magic, "VOX ") != 0, ERR_PARSE_ERROR);
 
-	const uint32_t version = f.get_32();
+	const uint32_t version = f->get_32();
 	ERR_FAIL_COND_V(version != 150, ERR_PARSE_ERROR);
 
-	const size_t file_length = f.get_length();
+	const size_t file_length = f->get_length();
 
 	Vector3i last_size;
 
 	clear();
 
-	while (f.get_position() < file_length) {
+	while (f->get_position() < file_length) {
 		char chunk_id[5] = { 0 };
-		ERR_FAIL_COND_V(f.get_buffer((uint8_t *)chunk_id, 4) != 4, ERR_PARSE_ERROR);
+		ERR_FAIL_COND_V(f->get_buffer((uint8_t *)chunk_id, 4) != 4, ERR_PARSE_ERROR);
 
-		const uint32_t chunk_size = f.get_32();
-		f.get_32(); // child_chunks_size
+		const uint32_t chunk_size = f->get_32();
+		f->get_32(); // child_chunks_size
 
-		ZN_PRINT_VERBOSE(format("Reading chunk {} at {}, size={}", chunk_id, f.get_position(), chunk_size));
+		ZN_PRINT_VERBOSE(format("Reading chunk {} at {}, size={}", chunk_id, f->get_position(), chunk_size));
 
 		if (strcmp(chunk_id, "SIZE") == 0) {
 			Vector3i size;
-			size.x = f.get_32();
-			size.y = f.get_32();
-			size.z = f.get_32();
+			size.x = f->get_32();
+			size.y = f->get_32();
+			size.z = f->get_32();
 			ERR_FAIL_COND_V(size.x > 256, ERR_PARSE_ERROR);
 			ERR_FAIL_COND_V(size.y > 256, ERR_PARSE_ERROR);
 			ERR_FAIL_COND_V(size.z > 256, ERR_PARSE_ERROR);
@@ -246,14 +245,14 @@ Error Data::_load_from_file(String fpath) {
 			model->color_indexes.resize(last_size.x * last_size.y * last_size.z, 0);
 			model->size = last_size;
 
-			const uint32_t num_voxels = f.get_32();
+			const uint32_t num_voxels = f->get_32();
 
 			for (uint32_t i = 0; i < num_voxels; ++i) {
 				Vector3i pos;
-				pos.x = f.get_8();
-				pos.y = f.get_8();
-				pos.z = f.get_8();
-				const uint32_t c = f.get_8();
+				pos.x = f->get_8();
+				pos.y = f->get_8();
+				pos.z = f->get_8();
+				const uint32_t c = f->get_8();
 				pos = magica_to_opengl(pos);
 				ERR_FAIL_COND_V(pos.x >= model->size.x || pos.x < 0, ERR_PARSE_ERROR);
 				ERR_FAIL_COND_V(pos.y >= model->size.y || pos.y < 0, ERR_PARSE_ERROR);
@@ -267,13 +266,13 @@ Error Data::_load_from_file(String fpath) {
 			_palette[0] = Color8{ 0, 0, 0, 0 };
 			for (uint32_t i = 1; i < _palette.size(); ++i) {
 				Color8 c;
-				c.r = f.get_8();
-				c.g = f.get_8();
-				c.b = f.get_8();
-				c.a = f.get_8();
+				c.r = f->get_8();
+				c.g = f->get_8();
+				c.b = f->get_8();
+				c.a = f->get_8();
 				_palette[i] = c;
 			}
-			f.get_32();
+			f->get_32();
 
 		} else if (strcmp(chunk_id, "nTRN") == 0) {
 			std::unique_ptr<TransformNode> node_ptr = std::make_unique<TransformNode>();
@@ -294,14 +293,14 @@ Error Data::_load_from_file(String fpath) {
 				node.hidden = false;
 			}
 
-			node.child_node_id = f.get_32();
+			node.child_node_id = f->get_32();
 
-			const int reserved_id = f.get_32();
+			const int reserved_id = f->get_32();
 			ERR_FAIL_COND_V(reserved_id != -1, ERR_INVALID_DATA);
 
-			node.layer_id = f.get_32();
+			node.layer_id = f->get_32();
 
-			const int frame_count = f.get_32();
+			const int frame_count = f->get_32();
 			ERR_FAIL_COND_V(frame_count != 1, ERR_INVALID_DATA);
 
 			//for (int frame_index = 0; frame_index < frame_count; ++frame_index) {
@@ -339,13 +338,13 @@ Error Data::_load_from_file(String fpath) {
 			Error header_err = parse_node_common_header(node, f, _scene_graph);
 			ERR_FAIL_COND_V(header_err != OK, header_err);
 
-			const unsigned int child_count = f.get_32();
+			const unsigned int child_count = f->get_32();
 			// Sanity check
 			ERR_FAIL_COND_V(child_count > 65536, ERR_INVALID_DATA);
 			node.child_node_ids.resize(child_count);
 
 			for (unsigned int i = 0; i < child_count; ++i) {
-				node.child_node_ids[i] = f.get_32();
+				node.child_node_ids[i] = f->get_32();
 			}
 
 			_scene_graph[node.id] = std::move(node_ptr);
@@ -357,12 +356,12 @@ Error Data::_load_from_file(String fpath) {
 			Error header_err = parse_node_common_header(node, f, _scene_graph);
 			ERR_FAIL_COND_V(header_err != OK, header_err);
 
-			const unsigned int model_count = f.get_32();
+			const unsigned int model_count = f->get_32();
 			ERR_FAIL_COND_V(model_count != 1, ERR_INVALID_DATA);
 
 			//for (unsigned int i = 0; i < model_count; ++i) {
 
-			node.model_id = f.get_32();
+			node.model_id = f->get_32();
 			ERR_FAIL_COND_V(node.model_id > 65536, ERR_INVALID_DATA);
 			ERR_FAIL_COND_V(node.model_id < 0, ERR_INVALID_DATA);
 
@@ -377,7 +376,7 @@ Error Data::_load_from_file(String fpath) {
 			std::unique_ptr<Layer> layer_ptr = std::make_unique<Layer>();
 			Layer &layer = *layer_ptr;
 
-			const int layer_id = f.get_32();
+			const int layer_id = f->get_32();
 			for (unsigned int i = 0; i < _layers.size(); ++i) {
 				const Layer *existing_layer = _layers[i].get();
 				CRASH_COND(existing_layer == nullptr);
@@ -401,7 +400,7 @@ Error Data::_load_from_file(String fpath) {
 				layer.hidden = false;
 			}
 
-			const int reserved_id = f.get_32();
+			const int reserved_id = f->get_32();
 			ERR_FAIL_COND_V(reserved_id != -1, ERR_INVALID_DATA);
 
 			_layers.push_back(std::move(layer_ptr));
@@ -410,7 +409,7 @@ Error Data::_load_from_file(String fpath) {
 			std::unique_ptr<Material> material_ptr = std::make_unique<Material>();
 			Material &material = *material_ptr;
 
-			const int material_id = f.get_32();
+			const int material_id = f->get_32();
 			ERR_FAIL_COND_V(material_id < 0 || material_id > static_cast<int>(_palette.size()), ERR_INVALID_DATA);
 			ERR_FAIL_COND_V_MSG(_materials.find(material_id) != _materials.end(), ERR_INVALID_DATA,
 					String("Material ID {0} already exists").format(varray(material_id)));
@@ -474,7 +473,7 @@ Error Data::_load_from_file(String fpath) {
 		} else {
 			ZN_PRINT_VERBOSE(format("Skipping chunk {}", chunk_id));
 			// Ignore chunk
-			f.seek(f.get_position() + chunk_size);
+			f->seek(f->get_position() + chunk_size);
 		}
 	}
 

--- a/streams/voxel_block_serializer.cpp
+++ b/streams/voxel_block_serializer.cpp
@@ -513,9 +513,9 @@ bool decompress_and_deserialize(Span<const uint8_t> p_data, VoxelBufferInternal 
 	return deserialize(to_span_const(data), out_voxel_buffer);
 }
 
-bool decompress_and_deserialize(FileAccess *f, unsigned int size_to_read, VoxelBufferInternal &out_voxel_buffer) {
+bool decompress_and_deserialize(Ref<FileAccess> f, unsigned int size_to_read, VoxelBufferInternal &out_voxel_buffer) {
 	ZN_PROFILE_SCOPE();
-	ERR_FAIL_COND_V(f == nullptr, false);
+	ERR_FAIL_COND_V(f.is_null(), false);
 
 #if defined(TOOLS_ENABLED) || defined(DEBUG_ENABLED)
 	const size_t fpos = f->get_position();

--- a/streams/voxel_block_serializer.h
+++ b/streams/voxel_block_serializer.h
@@ -28,7 +28,7 @@ bool deserialize(Span<const uint8_t> p_data, VoxelBufferInternal &out_voxel_buff
 
 SerializeResult serialize_and_compress(const VoxelBufferInternal &voxel_buffer);
 bool decompress_and_deserialize(Span<const uint8_t> p_data, VoxelBufferInternal &out_voxel_buffer);
-bool decompress_and_deserialize(FileAccess *f, unsigned int size_to_read, VoxelBufferInternal &out_voxel_buffer);
+bool decompress_and_deserialize(Ref<FileAccess> f, unsigned int size_to_read, VoxelBufferInternal &out_voxel_buffer);
 
 int serialize(StreamPeer &peer, VoxelBufferInternal &voxel_buffer, bool compress);
 void deserialize(StreamPeer &peer, VoxelBufferInternal &voxel_buffer, int size, bool decompress);

--- a/streams/voxel_stream_block_files.cpp
+++ b/streams/voxel_stream_block_files.cpp
@@ -51,7 +51,7 @@ void VoxelStreamBlockFiles::load_voxel_block(VoxelStream::VoxelQueryData &q) {
 	Vector3i block_pos = get_block_position(q.origin_in_voxels) >> q.lod;
 	String file_path = get_block_file_path(block_pos, q.lod);
 
-	FileAccess *f = nullptr;
+	Ref<FileAccess> f;
 	VoxelFileLockerRead file_rlock(file_path);
 	{
 		Error err;
@@ -70,7 +70,6 @@ void VoxelStreamBlockFiles::load_voxel_block(VoxelStream::VoxelQueryData &q) {
 			uint8_t version;
 			const FileResult err = check_magic_and_version(f, FORMAT_VERSION, FORMAT_BLOCK_MAGIC, version);
 			if (err != FILE_OK) {
-				memdelete(f);
 				ERR_PRINT(String("Invalid file header: ") + ::to_string(err));
 				return;
 			}
@@ -87,9 +86,6 @@ void VoxelStreamBlockFiles::load_voxel_block(VoxelStream::VoxelQueryData &q) {
 			ERR_PRINT("Failed to decompress and deserialize");
 		}
 	}
-
-	f->close();
-	memdelete(f);
 
 	q.result = RESULT_BLOCK_FOUND;
 }
@@ -134,7 +130,7 @@ void VoxelStreamBlockFiles::save_voxel_block(VoxelStream::VoxelQueryData &q) {
 	}
 
 	{
-		FileAccess *f = nullptr;
+		Ref<FileAccess> f;
 		VoxelFileLockerWrite file_wlock(file_path);
 		{
 			Error err;
@@ -148,15 +144,11 @@ void VoxelStreamBlockFiles::save_voxel_block(VoxelStream::VoxelQueryData &q) {
 
 		BlockSerializer::SerializeResult res = BlockSerializer::serialize_and_compress(q.voxel_buffer);
 		if (!res.success) {
-			memdelete(f);
 			ERR_PRINT("Failed to save block");
 			return;
 		}
 		f->store_32(res.data.size());
 		f->store_buffer(res.data.data(), res.data.size());
-
-		f->close();
-		memdelete(f);
 	}
 }
 
@@ -197,7 +189,7 @@ FileResult VoxelStreamBlockFiles::save_meta() {
 	{
 		Error err;
 		VoxelFileLockerWrite file_wlock(meta_path);
-		FileAccess *f = FileAccess::open(meta_path, FileAccess::WRITE, &err);
+		Ref<FileAccess> f = FileAccess::open(meta_path, FileAccess::WRITE, &err);
 		ERR_FAIL_COND_V(f == nullptr, FILE_CANT_OPEN);
 
 		f->store_buffer((uint8_t *)FORMAT_META_MAGIC, 4);
@@ -209,8 +201,6 @@ FileResult VoxelStreamBlockFiles::save_meta() {
 		for (unsigned int i = 0; i < _meta.channel_depths.size(); ++i) {
 			f->store_8(_meta.channel_depths[i]);
 		}
-
-		memdelete(f);
 	}
 
 	_meta_loaded = true;
@@ -237,15 +227,15 @@ FileResult VoxelStreamBlockFiles::load_meta() {
 	{
 		Error open_result;
 		VoxelFileLockerRead file_rlock(meta_path);
-		FileAccessRef f = FileAccess::open(meta_path, FileAccess::READ, &open_result);
+		Ref<FileAccess> f = FileAccess::open(meta_path, FileAccess::READ, &open_result);
 		// Had to add ERR_FILE_CANT_OPEN because that's what Godot actually returns when the file doesn't exist...
 		if (!_meta_saved && (open_result == ERR_FILE_NOT_FOUND || open_result == ERR_FILE_CANT_OPEN)) {
 			// This is a new terrain, save the meta we have and consider it current
 			return FILE_DOES_NOT_EXIST;
 		}
-		ERR_FAIL_COND_V(!f, FILE_CANT_OPEN);
+		ERR_FAIL_COND_V(f.is_null(), FILE_CANT_OPEN);
 
-		FileResult check_result = check_magic_and_version(f.f, FORMAT_VERSION, FORMAT_META_MAGIC, meta.version);
+		FileResult check_result = check_magic_and_version(f, FORMAT_VERSION, FORMAT_META_MAGIC, meta.version);
 		if (check_result != FILE_OK) {
 			return check_result;
 		}


### PR DESCRIPTION
Module was not building after latest Godot 4 changes.

Updates use of `FileAcess` and `DirAccess` to match the newly updated reference-counted versions
(see: https://github.com/godotengine/godot/pull/59440)