### PR TITLE
MacOS build: Fix size discrepancy between size_t and uint64_t in voxel_block_serializer.cpp

### DIFF
--- a/storage/voxel_metadata_variant.cpp
+++ b/storage/voxel_metadata_variant.cpp
@@ -17,7 +17,7 @@ size_t VoxelMetadataVariant::serialize(Span<uint8_t> dst) const {
 	return written_length;
 }
 
-bool VoxelMetadataVariant::deserialize(Span<const uint8_t> src, size_t &out_read_size) {
+bool VoxelMetadataVariant::deserialize(Span<const uint8_t> src, uint64_t &out_read_size) {
 	int read_length;
 	const Error err = decode_variant(data, src.data(), src.size(), &read_length, false);
 	ERR_FAIL_COND_V_MSG(err != OK, false, "Failed to deserialize block metadata");

--- a/storage/voxel_metadata_variant.cpp
+++ b/storage/voxel_metadata_variant.cpp
@@ -17,7 +17,7 @@ size_t VoxelMetadataVariant::serialize(Span<uint8_t> dst) const {
 	return written_length;
 }
 
-bool VoxelMetadataVariant::deserialize(Span<const uint8_t> src, uint64_t &out_read_size) {
+bool VoxelMetadataVariant::deserialize(Span<const uint8_t> src, size_t &out_read_size) {
 	int read_length;
 	const Error err = decode_variant(data, src.data(), src.size(), &read_length, false);
 	ERR_FAIL_COND_V_MSG(err != OK, false, "Failed to deserialize block metadata");

--- a/streams/voxel_block_serializer.cpp
+++ b/streams/voxel_block_serializer.cpp
@@ -179,7 +179,7 @@ static bool deserialize_metadata(VoxelMetadata &meta, MemoryReader &mr) {
 				VoxelMetadata temp;
 				temp.set_custom(type, custom);
 
-				size_t read_size = 0;
+				uint64_t read_size = 0;
 				ZN_ASSERT_RETURN_V(custom->deserialize(mr.data.sub(mr.pos), read_size), false);
 				ZN_ASSERT_RETURN_V(mr.pos + read_size <= mr.data.size(), false);
 				mr.pos += read_size;


### PR DESCRIPTION
Fixes https://github.com/Zylann/godot_voxel/issues/372

Currently in the process of making sure it doesn't break any of the builds, which is why this is still a DRAFT.

 - Non-Arm64 Mac Build works: `scons -j4 platform=osx CXX=clang++ osxcross_sdk=darwin20.4 warnings=all tools=yes tests=no target=release_debug production=yes`
   - (I removed the `werror=yes` for now, since Mac is not explicitly supported)
 - Arm64 Mac Build doesn't work yet because of some fast_noise issues: `scons -j4 platform=osx CXX=clang++ osxcross_sdk=darwin20.4 arch=arm64 warnings=all tools=yes tests=no target=release_debug production=yes`
    - It was related to #366 :
    - The command I'm currently trying is `scons -j4 voxel_fast_noise_2=false platform=osx CXX=clang++ osxcross_sdk=darwin20.4 arch=arm64 warnings=all tools=yes tests=no target=release_debug production=yes`
 <details><summary>console output</summary>
 $ scons -j4 platform=osx CXX=clang++ osxcross_sdk=darwin20.4 arch=arm64 warnings=all tools=yes tests=no target=release_debug production=yes
scons: Reading SConscript files ...
Building for macOS 11.0+, platform arm64.
Checking for C header file mntent.h... (cached) no
scons: done reading SConscript files.
scons: Building targets ...
[ 10%] Linking Static Library modules/libmodule_webp.osx.opt.tools.arm64.a ...
Ranlib Library modules/libmodule_webp.osx.opt.tools.arm64.a ...
[ 10%] Compiling modules/voxel/thirdparty/fast_noise_2/src/FastSIMD/FastSIMD.cpp ...
[ 10%] warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
[ 10%] Compiling modules/voxel/thirdparty/fast_noise_2/src/FastSIMD/FastSIMD_Level_SSE2.cpp ...
[ 10%] Compiling modules/voxel/thirdparty/fast_noise_2/src/FastSIMD/FastSIMD_Level_SSE3.cpp ...
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
[ 10%] Compiling modules/voxel/thirdparty/fast_noise_2/src/FastSIMD/FastSIMD_Level_SSSE3.cpp ...
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
1 warning generated.
[ 11%] 1 warning generated.
[ 11%] Compiling modules/voxel/thirdparty/fast_noise_2/src/FastSIMD/FastSIMD_Level_SSE41.cpp ...
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
[ 11%] 1 warning generated.
[ 11%] Compiling modules/voxel/thirdparty/fast_noise_2/src/FastSIMD/FastSIMD_Level_SSE42.cpp ...
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
1 warning generated.
[ 11%] Compiling modules/voxel/thirdparty/fast_noise_2/src/FastSIMD/FastSIMD_Level_AVX2.cpp ...
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
[ 11%] Compiling modules/voxel/thirdparty/fast_noise_2/src/FastSIMD/FastSIMD_Level_AVX512.cpp ...
1 warning generated.
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
1 warning generated.
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
1 warning generated.
[ 12%] Compiling modules/voxel/register_types.cpp ...
In file included from modules/voxel/thirdparty/fast_noise_2/src/FastSIMD/FastSIMD.cpp:7:
In file included from /usr/local/bin/../lib/clang/10.0.1/include/x86intrin.h:13:
/usr/local/bin/../lib/clang/10.0.1/include/ia32intrin.h:188:10: error: use of undeclared identifier '__builtin_ia32_readeflags_u32'
  return __builtin_ia32_readeflags_u32();
         ^
/usr/local/bin/../lib/clang/10.0.1/include/ia32intrin.h:194:3: error: use of undeclared identifier '__builtin_ia32_writeeflags_u32'
  __builtin_ia32_writeeflags_u32(__f);
  ^
/usr/local/bin/../lib/clang/10.0.1/include/ia32intrin.h:284:10: error: use of undeclared identifier '__builtin_ia32_crc32qi'
  return __builtin_ia32_crc32qi(__C, __D);
         ^
/usr/local/bin/../lib/clang/10.0.1/include/ia32intrin.h:305:10: error: use of undeclared identifier '__builtin_ia32_crc32hi'; did you mean '__builtin_arm_crc32h'?
  return __builtin_ia32_crc32hi(__C, __D);
         ^
/usr/local/bin/../lib/clang/10.0.1/include/ia32intrin.h:305:10: note: '__builtin_arm_crc32h' declared here
[ 12%] /usr/local/bin/../lib/clang/10.0.1/include/ia32intrin.h:326:10: error: use of undeclared identifier '__builtin_ia32_crc32si'
  return __builtin_ia32_crc32si(__C, __D);
         ^
[ 12%] Compiling modules/voxel/constants/cube_tables.cpp ...
/usr/local/bin/../lib/clang/10.0.1/include/ia32intrin.h:354:10: error: use of undeclared identifier '__builtin_ia32_rdpmc'; did you mean '__builtin_arm_dmb'?
  return __builtin_ia32_rdpmc(__A);
         ^
/usr/local/bin/../lib/clang/10.0.1/include/ia32intrin.h:354:10: note: '__builtin_arm_dmb' declared here
/usr/local/bin/../lib/clang/10.0.1/include/ia32intrin.h:354:10: error: argument to '__builtin_arm_dmb' must be a constant integer
  return __builtin_ia32_rdpmc(__A);
         ^                    ~~~
/usr/local/bin/../lib/clang/10.0.1/include/ia32intrin.h:360:10: error: use of undeclared identifier '__builtin_ia32_rdtscp'; did you mean '__builtin_arm_rsrp'?
  return __builtin_ia32_rdtscp(__A);
         ^
/usr/local/bin/../lib/clang/10.0.1/include/ia32intrin.h:360:10: note: '__builtin_arm_rsrp' declared here
/usr/local/bin/../lib/clang/10.0.1/include/ia32intrin.h:360:32: error: cannot initialize a parameter of type 'const char *' with an lvalue of type 'unsigned int *'
  return __builtin_ia32_rdtscp(__A);
                               ^~~
/usr/local/bin/../lib/clang/10.0.1/include/ia32intrin.h:369:3: error: use of undeclared identifier '__builtin_ia32_wbinvd'
  __builtin_ia32_wbinvd();
  ^
In file included from modules/voxel/thirdparty/fast_noise_2/src/FastSIMD/FastSIMD.cpp:7:
In file included from /usr/local/bin/../lib/clang/10.0.1/include/x86intrin.h:15:
In file included from /usr/local/bin/../lib/clang/10.0.1/include/immintrin.h:14:
/usr/local/bin/../lib/clang/10.0.1/include/mmintrin.h:33:5: error: use of undeclared identifier '__builtin_ia32_emms'; did you mean '__builtin_isless'?
    __builtin_ia32_emms();
    ^
/usr/local/bin/../lib/clang/10.0.1/include/mmintrin.h:33:5: note: '__builtin_isless' declared here
/usr/local/bin/../lib/clang/10.0.1/include/mmintrin.h:33:25: error: too few arguments to function call, expected 2, have 0
    __builtin_ia32_emms();
                        ^
[ 12%] Compiling modules/voxel/constants/voxel_string_names.cpp ...
/usr/local/bin/../lib/clang/10.0.1/include/mmintrin.h:50:19: error: use of undeclared identifier '__builtin_ia32_vec_init_v2si'
    return (__m64)__builtin_ia32_vec_init_v2si(__i, 0);
                  ^
/usr/local/bin/../lib/clang/10.0.1/include/mmintrin.h:67:12: error: use of undeclared identifier '__builtin_ia32_vec_ext_v2si'
    return __builtin_ia32_vec_ext_v2si((__v2si)__m, 0);
           ^
/usr/local/bin/../lib/clang/10.0.1/include/mmintrin.h:129:19: error: use of undeclared identifier '__builtin_ia32_packsswb'
    return (__m64)__builtin_ia32_packsswb((__v4hi)__m1, (__v4hi)__m2);
                  ^
/usr/local/bin/../lib/clang/10.0.1/include/mmintrin.h:159:19: error: use of undeclared identifier '__builtin_ia32_packssdw'
    return (__m64)__builtin_ia32_packssdw((__v2si)__m1, (__v2si)__m2);
                  ^
/usr/local/bin/../lib/clang/10.0.1/include/mmintrin.h:189:19: error: use of undeclared identifier '__builtin_ia32_packuswb'
    return (__m64)__builtin_ia32_packuswb((__v4hi)__m1, (__v4hi)__m2);
                  ^
/usr/local/bin/../lib/clang/10.0.1/include/mmintrin.h:216:19: error: use of undeclared identifier '__builtin_ia32_punpckhbw'
    return (__m64)__builtin_ia32_punpckhbw((__v8qi)__m1, (__v8qi)__m2);
                  ^
/usr/local/bin/../lib/clang/10.0.1/include/mmintrin.h:239:19: error: use of undeclared identifier '__builtin_ia32_punpckhwd'
    return (__m64)__builtin_ia32_punpckhwd((__v4hi)__m1, (__v4hi)__m2);
                  ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
1 warning and 20 errors generated.
scons: *** [modules/voxel/thirdparty/fast_noise_2/src/FastSIMD/FastSIMD.osx.opt.tools.arm64.o] Error 1
Transferring 1 itemscons: building terminated because of errors.
[Time elapsed: 00:00:13.401]
  </details>

 - My linux build works `scons -j4  warnings=all werror=yes platform=linuxbsd tools=yes tests=no target=release_debug production=yes float=32`
 - The windows build works too, when `werror=no`: `scons -j4  warnings=all platform=windows tools=yes tests=no target=release_debug production=yes float=32` Though I have some errors that I'll have to look into real quick
    - I still need to retry to fix the warning that make it fail when `werror=yes`
 