### PR TITLE
DOC: Make it clearer where to look on building mismatch

### DIFF
--- a/doc/source/getting_the_module.md
+++ b/doc/source/getting_the_module.md
@@ -32,7 +32,7 @@ In case there are multiple downloadable artifacts, the editor build will be the 
 	You will need a Github account to be able to download development builds. Otherwise, links will not work.
 
 !!! warning
-	Godot 4 has no stable version yet. It has the very latest new features but will be full of bugs. It is possible to work with it, but be aware many features may not work correctly and errors will often show up.
+	Godot 4 has no stable version yet. It has the very latest new features but will be full of bugs. It is possible to work with it, but be aware many features may not work correctly and errors will often show up. If your build errors out, check the github actions for the latest godot git commit working with the latest Zylann/godot_voxel commit: https://github.com/Zylann/godot_voxel/actions
 
 #### For Godot 3 (legacy builds)
 


### PR DESCRIPTION
When the latest godot commit and the latest godot_voxel commit don't match, look at the latest successful Github action.

Also the godot_voxel/master is targeting the tip of the godot/master, so with breaking changes, a recent voxel/master commit won't work with all recent godot/master commits.

Still a first draft of what could be said, I'll try sleeping on it to come up with something clearer or at a better place in the doc