### PR TITLE
Cross-compiler compatibility: const -> constexpr

### DIFF
--- a/meshers/blocky/voxel_blocky_model.h
+++ b/meshers/blocky/voxel_blocky_model.h
@@ -63,7 +63,7 @@ public:
 		};
 
 		struct Model {
-			static const uint32_t MAX_SURFACES = 2;
+			static constexpr uint32_t MAX_SURFACES = 2;
 
 			// A model can have up to 2 materials.
 			// If more is needed or profiling tells better, we could change it to a vector?


### PR DESCRIPTION
As suggested in https://github.com/Zylann/godot_voxel/issues/387
This allowed 2 full Mac builds using these commands:
 ```
scons platform=osx arch=x86_64 --jobs=$(sysctl -n hw.logicalcpu) warnings=all tools=yes tests=no target=release_debug production=yes
 ```
```
scons platform=osx arch=arm64 --jobs=$(sysctl -n hw.logicalcpu) warnings=all tools=yes tests=no target=release_debug production=yes voxel_fast_noise_2=false 
```
 -


( Also after having the VulkanSDK like mentioned here[1] and after deleting the `denoise` module which doesn't like ARM64)

[1]: https://github.com/godotengine/godot/issues/57622#issuecomment-1120486153