### PR TITLE
Avoid unused variable warning.

### DIFF
--- a/streams/region/region_file.cpp
+++ b/streams/region/region_file.cpp
@@ -98,8 +98,8 @@ static bool save_header(
 	// TODO Deal with endianess, this should be little-endian
 	f.store_buffer(reinterpret_cast<const uint8_t *>(block_infos.data()), block_infos.size() * sizeof(RegionBlockInfo));
 
-	const size_t blocks_begin_offset = f.get_position();
 #ifdef DEBUG_ENABLED
+	const size_t blocks_begin_offset = f.get_position();
 	CRASH_COND(blocks_begin_offset != get_header_size_v3(format));
 #endif
 


### PR DESCRIPTION
gcc warns:

```
modules/voxel/streams/region/region_file.cpp: In function 'bool save_header(FileAccess*, uint8_t, const VoxelRegionFormat&, const std::vector<VoxelRegionBlockInfo>&)':
832
modules/voxel/streams/region/region_file.cpp:101:9: error: unused variable 'blocks_begin_offset' [-Werror=unused-variable]
833
  101 |  size_t blocks_begin_offset = f->get_position();

	const size_t blocks_begin_offset = f.get_position();
```

I noticed this while trying to build export templates using github
actions, as the godot actions treat warnings as errors by default:

https://github.com/rcorre/godot/runs/6617207436
