### PR TITLE
Fix mac compilation on 3.x.

### DIFF
--- a/server/voxel_server.cpp
+++ b/server/voxel_server.cpp
@@ -889,7 +889,7 @@ void VoxelServer::AllBlocksDataRequest::run(VoxelTaskContext ctx) {
 
 	stream->load_all_blocks(result);
 
-	PRINT_VERBOSE(String("Loaded {0} blocks for volume {1}").format(varray(result.blocks.size(), volume_id)));
+	PRINT_VERBOSE(String("Loaded {0} blocks for volume {1}").format(varray(SIZE_T_TO_VARIANT(result.blocks.size()), volume_id)));
 }
 
 int VoxelServer::AllBlocksDataRequest::get_priority() {


### PR DESCRIPTION
Compiling for mac fails with:
```
clang++ -o modules/voxel/server/voxel_server.osx.opt.64.o -c -std=gnu++14 -Wno-inconsistent-missing-override -msse2 -O3 -fomit-frame-pointer -ftree-vectorize -arch x86_64 -mmacosx-version-min=10.12 -isysroot /Applications/Xcode_13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk -w -DNO_EDITOR_SPLASH -DOSX_ENABLED -DUNIX_ENABLED -DGLES_ENABLED -DAPPLE_STYLE_KEYS -DCOREAUDIO_ENABLED -DCOREMIDI_ENABLED -DGL_SILENCE_DEPRECATION -DNDEBUG -DPTRCALL_ENABLED -DMINIZIP_ENABLED -DZSTD_STATIC_LINKING_ONLY -DGLAD_ENABLED -DGLES_OVER_GL -DMESHOPTIMIZER_ZYLANN_NEVER_COLLAPSE_BORDERS -Ithirdparty/libpng -Ithirdparty/glad -Ithirdparty/zstd -Ithirdparty/zlib -Iplatform/osx -I. modules/voxel/server/voxel_server.cpp
869
modules/voxel/server/voxel_server.cpp:892:87: error: conversion from 'std::vector<VoxelStream::FullLoadingResult::Block>::size_type' (aka 'unsigned long') to 'const Variant' is ambiguous
870
        PRINT_VERBOSE(String("Loaded {0} blocks for volume {1}").format(varray(result.blocks.size(), volume_id)));
```

See https://github.com/rcorre/godot/runs/6617780963.

`main` uses a different format method, where this doesn't seem to be an issue.