### PR TITLE
Use the new project name and avoid a URL redirect.

### DIFF
--- a/.github/workflows/test_project.yml
+++ b/.github/workflows/test_project.yml
@@ -80,9 +80,9 @@ jobs:
       # Download and extract zip archive with project, folder is renamed to be able to easy change used project
       - name: Download test project
         run: |
-          wget https://github.com/godotengine/regression-test-project/archive/master.zip
-          unzip master.zip
-          mv "regression-test-project-3.x" "test_project"
+          wget https://github.com/godotengine/regression-test-project/archive/refs/heads/4.0.zip
+          unzip 4.0.zip
+          mv "regression-test-project-4.0" "test_project"
 
       # Editor is quite complicated piece of software, so it is easy to introduce bug here
       - name: Open and close editor

--- a/.github/workflows/test_project.yml
+++ b/.github/workflows/test_project.yml
@@ -80,9 +80,9 @@ jobs:
       # Download and extract zip archive with project, folder is renamed to be able to easy change used project
       - name: Download test project
         run: |
-          wget https://github.com/qarmin/RegressionTestProject/archive/master.zip
+          wget https://github.com/godotengine/regression-test-project/archive/master.zip
           unzip master.zip
-          mv "RegressionTestProject-master" "test_project"
+          mv "regression-test-project-3.x" "test_project"
 
       # Editor is quite complicated piece of software, so it is easy to introduce bug here
       - name: Open and close editor


### PR DESCRIPTION
Related to issue #397:
- Use the updated URL (I used the URL to which the old URL redirects).
- Use the updated project name (since an invalid source in `mv` command was causing a test to fail on all commits).

This PR only fixes master (I will also look at 3.x branch and add another PR as necessary).