### PR TITLE
Use the new project name and avoid a URL redirect (Fix #397).

### DIFF
--- a/.github/workflows/test_project.yml
+++ b/.github/workflows/test_project.yml
@@ -80,9 +80,9 @@ jobs:
       # Download and extract zip archive with project, folder is renamed to be able to easy change used project
       - name: Download test project
         run: |
-          wget https://github.com/qarmin/RegressionTestProject/archive/3.x.zip
+          wget https://github.com/godotengine/regression-test-project/archive/3.x.zip
           unzip 3.x.zip
-          mv "RegressionTestProject-3.x" "test_project"
+          mv "regression-test-project-3.x" "test_project"
 
       # Editor is quite complicated piece of software, so it is easy to introduce bug here
       - name: Open and close editor


### PR DESCRIPTION
Related to issue #397:
- Use the updated URL (I used the URL to which the old URL redirects).
- Use the updated project name (since an invalid source in `mv` command was causing a test to fail on all commits).

This PR only fixes the godot3.x branch.
- This one downloads the 3.x branch of the regression test project, so it differs from my PR for the master branch.
- Let me know: Are both this and that PR fine, or how are you approaching the master branch?