### PR TITLE
Add `*.tmp` to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-*.obj
-*.pyc
-*.o
 *.autosave
 *.bc
 *.d
 *.log
+*.o
+*.obj
+*.pyc
+*.tmp


### PR DESCRIPTION
When compiling, I got temporary files showing up in my Git client with the extension `.tmp`. This PR ignores them. I also alphabetized the list so it's easy to find things.