### PR TITLE
Rename translated to translated_local

### DIFF
--- a/edition/voxel_tool_lod_terrain.cpp
+++ b/edition/voxel_tool_lod_terrain.cpp
@@ -651,7 +651,7 @@ Array separate_floating_chunks(VoxelTool &voxel_tool, Box3i world_box, Node *par
 			collision_shape->set_position(offset);
 
 			RigidDynamicBody3D *rigid_body = memnew(RigidDynamicBody3D);
-			rigid_body->set_transform(transform * local_transform.translated(-offset));
+			rigid_body->set_transform(transform * local_transform.translated_local(-offset));
 			rigid_body->add_child(collision_shape);
 			rigid_body->set_freeze_mode(RigidDynamicBody3D::FREEZE_MODE_KINEMATIC);
 			rigid_body->set_freeze_enabled(true);


### PR DESCRIPTION
This is necessary after https://github.com/godotengine/godot/pull/57698 was merged into the engine.