### PR TITLE
Run doctool, use "param" instead of "argument"

### DIFF
--- a/doc/classes/VoxelBlockSerializer.xml
+++ b/doc/classes/VoxelBlockSerializer.xml
@@ -27,19 +27,19 @@
 	<methods>
 		<method name="deserialize">
 			<return type="void" />
-			<argument index="0" name="peer" type="StreamPeer" />
-			<argument index="1" name="voxel_buffer" type="VoxelBuffer" />
-			<argument index="2" name="size" type="int" />
-			<argument index="3" name="decompress" type="bool" />
+			<param index="0" name="peer" type="StreamPeer" />
+			<param index="1" name="voxel_buffer" type="VoxelBuffer" />
+			<param index="2" name="size" type="int" />
+			<param index="3" name="decompress" type="bool" />
 			<description>
 				Reads the data of a [VoxelBuffer] from a [StreamPeer]. You must provide the number of bytes to read, and the destination buffer must have the expected size.
 			</description>
 		</method>
 		<method name="serialize">
 			<return type="int" />
-			<argument index="0" name="peer" type="StreamPeer" />
-			<argument index="1" name="voxel_buffer" type="VoxelBuffer" />
-			<argument index="2" name="compress" type="bool" />
+			<param index="0" name="peer" type="StreamPeer" />
+			<param index="1" name="voxel_buffer" type="VoxelBuffer" />
+			<param index="2" name="compress" type="bool" />
 			<description>
 				Stores the data of a [VoxelBuffer] into a [StreamPeer]. Returns the number of written bytes.
 			</description>

--- a/doc/classes/VoxelBlockyLibrary.xml
+++ b/doc/classes/VoxelBlockyLibrary.xml
@@ -19,12 +19,12 @@
 		</method>
 		<method name="create_voxel">
 			<return type="VoxelBlockyModel" />
-			<argument index="0" name="id" type="int" />
-				ID of the model. It must be comprised between 0 and [member voxel_count] excluded. This ID will be used in voxel data.
-			<argument index="1" name="name" type="String" />
-				Name of the model. It is convenient to give one for better organization.
+			<param index="0" name="id" type="int" />
+			<param index="1" name="name" type="String" />
 			<description>
 				Creates a new model attached to this library.
+				[code]id[/code]: ID of the model. It must be comprised between 0 and [member voxel_count] excluded. This ID will be used in voxel data.
+				[code]name[/code]: Name of the model. It is convenient to give one for better organization.
 			</description>
 		</method>
 		<method name="get_materials" qualifiers="const">
@@ -36,21 +36,21 @@
 		</method>
 		<method name="get_voxel">
 			<return type="VoxelBlockyModel" />
-			<argument index="0" name="id" type="int" />
+			<param index="0" name="id" type="int" />
 			<description>
 				Gets a model from its ID.
 			</description>
 		</method>
 		<method name="get_voxel_by_name">
 			<return type="VoxelBlockyModel" />
-			<argument index="0" name="name" type="StringName" />
+			<param index="0" name="name" type="StringName" />
 			<description>
 				Finds the first model having the specified name. If not found, returns [code]null[/code].
 			</description>
 		</method>
 		<method name="get_voxel_index_from_name" qualifiers="const">
 			<return type="int" />
-			<argument index="0" name="name" type="StringName" />
+			<param index="0" name="name" type="StringName" />
 			<description>
 				Finds the ID of the first model having the specified name. If not found, returns [code]null[/code].
 			</description>

--- a/doc/classes/VoxelBlockyModel.xml
+++ b/doc/classes/VoxelBlockyModel.xml
@@ -18,7 +18,7 @@
 		</method>
 		<method name="get_material_override" qualifiers="const">
 			<return type="Material" />
-			<argument index="0" name="index" type="int" />
+			<param index="0" name="index" type="int" />
 			<description>
 				Gets the material override for a specific surface of the model.
 			</description>
@@ -31,14 +31,14 @@
 		</method>
 		<method name="is_mesh_collision_enabled" qualifiers="const">
 			<return type="bool" />
-			<argument index="0" name="arg0" type="int" />
+			<param index="0" name="_unnamed_arg0" type="int" />
 			<description>
 				Tells if a specific surface produces mesh-based collisions.
 			</description>
 		</method>
 		<method name="set_id">
 			<return type="void" />
-			<argument index="0" name="id" type="int" />
+			<param index="0" name="id" type="int" />
 			<description>
 				Sets the ID of the model.
 				This method is deprecated. Changing the ID of a model after it's been added to a library is not supported.
@@ -46,16 +46,16 @@
 		</method>
 		<method name="set_material_override">
 			<return type="void" />
-			<argument index="0" name="index" type="int" />
-			<argument index="1" name="material" type="Material" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="material" type="Material" />
 			<description>
 				Sets a material override for a specific surface of the model. It allows to use the same mesh on multiple models, but using different materials on each.
 			</description>
 		</method>
 		<method name="set_mesh_collision_enabled">
 			<return type="void" />
-			<argument index="0" name="surface_index" type="int" />
-			<argument index="1" name="enabled" type="bool" />
+			<param index="0" name="surface_index" type="int" />
+			<param index="1" name="enabled" type="bool" />
 			<description>
 				Enables or disables mesh-based collision on a specific surface. It allows a model to have solid parts and others where players can pass through.
 			</description>

--- a/doc/classes/VoxelBoxMover.xml
+++ b/doc/classes/VoxelBoxMover.xml
@@ -28,10 +28,10 @@
 		</method>
 		<method name="get_motion">
 			<return type="Vector3" />
-			<argument index="0" name="pos" type="Vector3" />
-			<argument index="1" name="motion" type="Vector3" />
-			<argument index="2" name="aabb" type="AABB" />
-			<argument index="3" name="terrain" type="Node" />
+			<param index="0" name="pos" type="Vector3" />
+			<param index="1" name="motion" type="Vector3" />
+			<param index="2" name="aabb" type="AABB" />
+			<param index="3" name="terrain" type="Node" />
 			<description>
 				Given a motion vector, returns a modified vector telling you by how much to move your character. This is similar to [method KinematicBody.move_and_slide], except you have to apply the movement.
 			</description>
@@ -51,7 +51,7 @@
 		</method>
 		<method name="set_collision_mask">
 			<return type="void" />
-			<argument index="0" name="mask" type="int" />
+			<param index="0" name="mask" type="int" />
 			<description>
 				Sets the collision mask used to detect collidable voxels.
 				Only voxels sharing at least one bit between the masks will be detected.
@@ -60,14 +60,14 @@
 		</method>
 		<method name="set_max_step_height">
 			<return type="void" />
-			<argument index="0" name="height" type="float" />
+			<param index="0" name="height" type="float" />
 			<description>
 				Sets the maximum height that can be climbed like "stairs".
 			</description>
 		</method>
 		<method name="set_step_climbing_enabled">
 			<return type="void" />
-			<argument index="0" name="enabled" type="bool" />
+			<param index="0" name="enabled" type="bool" />
 			<description>
 				When enabled, [method get_motion] will attempt to climb up small steps. This allows to implement Minecraft-like stairs.
 			</description>

--- a/doc/classes/VoxelBuffer.xml
+++ b/doc/classes/VoxelBuffer.xml
@@ -24,8 +24,8 @@
 		</method>
 		<method name="clear_voxel_metadata_in_area">
 			<return type="void" />
-			<argument index="0" name="min_pos" type="Vector3i" />
-			<argument index="1" name="max_pos" type="Vector3i" />
+			<param index="0" name="min_pos" type="Vector3i" />
+			<param index="1" name="max_pos" type="Vector3i" />
 			<description>
 				Erases per-voxel metadata within the specified area.
 			</description>
@@ -37,19 +37,19 @@
 		</method>
 		<method name="copy_channel_from">
 			<return type="void" />
-			<argument index="0" name="other" type="VoxelBuffer" />
-			<argument index="1" name="channel" type="int" />
+			<param index="0" name="other" type="VoxelBuffer" />
+			<param index="1" name="channel" type="int" />
 			<description>
 				Copies all values from the channel of another [VoxelBuffer] into the same channel for the current buffer. The depth formats must match.
 			</description>
 		</method>
 		<method name="copy_channel_from_area">
 			<return type="void" />
-			<argument index="0" name="other" type="VoxelBuffer" />
-			<argument index="1" name="src_min" type="Vector3i" />
-			<argument index="2" name="src_max" type="Vector3i" />
-			<argument index="3" name="dst_min" type="Vector3i" />
-			<argument index="4" name="channel" type="int" />
+			<param index="0" name="other" type="VoxelBuffer" />
+			<param index="1" name="src_min" type="Vector3i" />
+			<param index="2" name="src_max" type="Vector3i" />
+			<param index="3" name="dst_min" type="Vector3i" />
+			<param index="4" name="channel" type="int" />
 			<description>
 				Copies values from a channel's sub-region of another [VoxelBuffer] into the same channel for the current buffer, at a specific location. The depth formats must match.
 				If corners of the area represent a negative-size area, they will be sorted back.
@@ -59,10 +59,10 @@
 		</method>
 		<method name="copy_voxel_metadata_in_area">
 			<return type="void" />
-			<argument index="0" name="src_buffer" type="VoxelBuffer" />
-			<argument index="1" name="src_min_pos" type="Vector3i" />
-			<argument index="2" name="src_max_pos" type="Vector3i" />
-			<argument index="3" name="dst_min_pos" type="Vector3i" />
+			<param index="0" name="src_buffer" type="VoxelBuffer" />
+			<param index="1" name="src_min_pos" type="Vector3i" />
+			<param index="2" name="src_max_pos" type="Vector3i" />
+			<param index="3" name="dst_min_pos" type="Vector3i" />
 			<description>
 				Copies per-voxel metadata from a sub-region of another [VoxelBuffer] into the the current buffer, at a specific location. Values will be a shallow copy.
 				If corners of the area represent a negative-size area, they will be sorted back.
@@ -72,25 +72,25 @@
 		</method>
 		<method name="create">
 			<return type="void" />
-			<argument index="0" name="sx" type="int" />
-			<argument index="1" name="sy" type="int" />
-			<argument index="2" name="sz" type="int" />
+			<param index="0" name="sx" type="int" />
+			<param index="1" name="sy" type="int" />
+			<param index="2" name="sz" type="int" />
 			<description>
 				Clears the buffer and gives it the specified size.
 			</description>
 		</method>
 		<method name="debug_print_sdf_y_slices" qualifiers="const">
 			<return type="Array" />
-			<argument index="0" name="scale" type="float" />
+			<param index="0" name="scale" type="float" />
 			<description>
 			</description>
 		</method>
 		<method name="downscale_to" qualifiers="const">
 			<return type="void" />
-			<argument index="0" name="dst" type="VoxelBuffer" />
-			<argument index="1" name="src_min" type="Vector3i" />
-			<argument index="2" name="src_max" type="Vector3i" />
-			<argument index="3" name="dst_min" type="Vector3i" />
+			<param index="0" name="dst" type="VoxelBuffer" />
+			<param index="1" name="src_min" type="Vector3i" />
+			<param index="2" name="src_max" type="Vector3i" />
+			<param index="3" name="dst_min" type="Vector3i" />
 			<description>
 				Produces a downscaled version of this buffer, by a factor of 2, without any form of interpolation (i.e using nearest-neighbor).
 				Metadata is not copied.
@@ -98,33 +98,33 @@
 		</method>
 		<method name="fill">
 			<return type="void" />
-			<argument index="0" name="value" type="int" />
-			<argument index="1" name="channel" type="int" default="0" />
+			<param index="0" name="value" type="int" />
+			<param index="1" name="channel" type="int" default="0" />
 			<description>
 				Fills one channel of this buffer with a specific raw value.
 			</description>
 		</method>
 		<method name="fill_area">
 			<return type="void" />
-			<argument index="0" name="value" type="int" />
-			<argument index="1" name="min" type="Vector3i" />
-			<argument index="2" name="max" type="Vector3i" />
-			<argument index="3" name="channel" type="int" default="0" />
+			<param index="0" name="value" type="int" />
+			<param index="1" name="min" type="Vector3i" />
+			<param index="2" name="max" type="Vector3i" />
+			<param index="3" name="channel" type="int" default="0" />
 			<description>
 				Fills an area of a channel in this buffer with a specific raw value.
 			</description>
 		</method>
 		<method name="fill_f">
 			<return type="void" />
-			<argument index="0" name="value" type="float" />
-			<argument index="1" name="channel" type="int" default="0" />
+			<param index="0" name="value" type="float" />
+			<param index="1" name="channel" type="int" default="0" />
 			<description>
 				Fills one channel of this buffer with a specific float value.
 			</description>
 		</method>
 		<method name="for_each_voxel_metadata" qualifiers="const">
 			<return type="void" />
-			<argument index="0" name="callback" type="Callable" />
+			<param index="0" name="callback" type="Callable" />
 			<description>
 				Executes a function on every voxel in this buffer which have associated metadata.
 				The function's arguments must be (position: Vector3i, metadata: Variant).
@@ -133,9 +133,9 @@
 		</method>
 		<method name="for_each_voxel_metadata_in_area">
 			<return type="void" />
-			<argument index="0" name="callback" type="Callable" />
-			<argument index="1" name="min_pos" type="Vector3i" />
-			<argument index="2" name="max_pos" type="Vector3i" />
+			<param index="0" name="callback" type="Callable" />
+			<param index="1" name="min_pos" type="Vector3i" />
+			<param index="2" name="max_pos" type="Vector3i" />
 			<description>
 				Executes a function on every voxel in this buffer which have associated metadata, within the specified area.
 			</description>
@@ -148,14 +148,14 @@
 		</method>
 		<method name="get_channel_compression" qualifiers="const">
 			<return type="int" enum="VoxelBuffer.Compression" />
-			<argument index="0" name="channel" type="int" />
+			<param index="0" name="channel" type="int" />
 			<description>
 				Gets which compression mode the specified channel has.
 			</description>
 		</method>
 		<method name="get_channel_depth" qualifiers="const">
 			<return type="int" enum="VoxelBuffer.Depth" />
-			<argument index="0" name="channel" type="int" />
+			<param index="0" name="channel" type="int" />
 			<description>
 				Gets which bit depth the specified channel has.
 			</description>
@@ -166,47 +166,29 @@
 				Gets the 3D size of the buffer in voxels.
 			</description>
 		</method>
-		<method name="get_size_x" qualifiers="const">
-			<return type="int" />
-			<description>
-				Gets how many voxels the buffer contains across the X axis.
-			</description>
-		</method>
-		<method name="get_size_y" qualifiers="const">
-			<return type="int" />
-			<description>
-				Gets how many voxels the buffer contains across the Y axis.
-			</description>
-		</method>
-		<method name="get_size_z" qualifiers="const">
-			<return type="int" />
-			<description>
-				Gets how many voxels the buffer contains across the Z axis.
-			</description>
-		</method>
 		<method name="get_voxel" qualifiers="const">
 			<return type="int" />
-			<argument index="0" name="x" type="int" />
-			<argument index="1" name="y" type="int" />
-			<argument index="2" name="z" type="int" />
-			<argument index="3" name="channel" type="int" default="0" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<param index="2" name="z" type="int" />
+			<param index="3" name="channel" type="int" default="0" />
 			<description>
 				Gets the raw value of a voxel within this buffer.
 			</description>
 		</method>
 		<method name="get_voxel_f" qualifiers="const">
 			<return type="float" />
-			<argument index="0" name="x" type="int" />
-			<argument index="1" name="y" type="int" />
-			<argument index="2" name="z" type="int" />
-			<argument index="3" name="channel" type="int" default="0" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<param index="2" name="z" type="int" />
+			<param index="3" name="channel" type="int" default="0" />
 			<description>
 				Gets the float value of a voxel within this buffer. You may use this function if you work with SDF volumes (smooth voxels).
 			</description>
 		</method>
 		<method name="get_voxel_metadata" qualifiers="const">
 			<return type="Variant" />
-			<argument index="0" name="pos" type="Vector3i" />
+			<param index="0" name="pos" type="Vector3i" />
 			<description>
 				Gets the metadata attached to a specific voxel in this buffer.
 			</description>
@@ -219,7 +201,7 @@
 		</method>
 		<method name="is_uniform" qualifiers="const">
 			<return type="bool" />
-			<argument index="0" name="channel" type="int" />
+			<param index="0" name="channel" type="int" />
 			<description>
 				Checks if every voxel within a channel has the same value.
 			</description>
@@ -231,7 +213,7 @@
 		</method>
 		<method name="set_block_metadata">
 			<return type="void" />
-			<argument index="0" name="meta" type="Variant" />
+			<param index="0" name="meta" type="Variant" />
 			<description>
 				Sets arbitrary data on this buffer. Old data is replaced. Note, this is separate storage from per-voxel metadata.
 				If this [VoxelBuffer] is saved, this metadata will also be saved along voxels, so make sure the data supports serialization (i.e you can't put nodes or arbitrary objects in it).
@@ -239,38 +221,38 @@
 		</method>
 		<method name="set_channel_depth">
 			<return type="void" />
-			<argument index="0" name="channel" type="int" />
-			<argument index="1" name="depth" type="int" enum="VoxelBuffer.Depth" />
+			<param index="0" name="channel" type="int" />
+			<param index="1" name="depth" type="int" enum="VoxelBuffer.Depth" />
 			<description>
 				Changes the bit depth of a given channel. This controls the range of values a channel can hold. See [enum VoxelBuffer.Depth] for more information.
 			</description>
 		</method>
 		<method name="set_voxel">
 			<return type="void" />
-			<argument index="0" name="value" type="int" />
-			<argument index="1" name="x" type="int" />
-			<argument index="2" name="y" type="int" />
-			<argument index="3" name="z" type="int" />
-			<argument index="4" name="channel" type="int" default="0" />
+			<param index="0" name="value" type="int" />
+			<param index="1" name="x" type="int" />
+			<param index="2" name="y" type="int" />
+			<param index="3" name="z" type="int" />
+			<param index="4" name="channel" type="int" default="0" />
 			<description>
 				Sets the raw value of a voxel. If you use smooth voxels, you may prefer using [method set_voxel_f].
 			</description>
 		</method>
 		<method name="set_voxel_f">
 			<return type="void" />
-			<argument index="0" name="value" type="float" />
-			<argument index="1" name="x" type="int" />
-			<argument index="2" name="y" type="int" />
-			<argument index="3" name="z" type="int" />
-			<argument index="4" name="channel" type="int" default="0" />
+			<param index="0" name="value" type="float" />
+			<param index="1" name="x" type="int" />
+			<param index="2" name="y" type="int" />
+			<param index="3" name="z" type="int" />
+			<param index="4" name="channel" type="int" default="0" />
 			<description>
 				Sets the float value of a voxel. This method should be used if you work on SDF data (smooth voxels).
 			</description>
 		</method>
 		<method name="set_voxel_metadata">
 			<return type="void" />
-			<argument index="0" name="pos" type="Vector3i" />
-			<argument index="1" name="value" type="Variant" />
+			<param index="0" name="pos" type="Vector3i" />
+			<param index="1" name="value" type="Variant" />
 			<description>
 				Attaches arbitrary data on a specific voxel. Old data is replaced.
 				If this [VoxelBuffer] is saved, this metadata will also be saved along voxels, so make sure the data supports serialization (i.e you can't put nodes or arbitrary objects in it).
@@ -278,9 +260,9 @@
 		</method>
 		<method name="set_voxel_v">
 			<return type="void" />
-			<argument index="0" name="value" type="int" />
-			<argument index="1" name="pos" type="Vector3i" />
-			<argument index="2" name="channel" type="int" default="0" />
+			<param index="0" name="value" type="int" />
+			<param index="1" name="pos" type="Vector3i" />
+			<param index="2" name="channel" type="int" default="0" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelColorPalette.xml
+++ b/doc/classes/VoxelColorPalette.xml
@@ -12,14 +12,14 @@
 	<methods>
 		<method name="get_color" qualifiers="const">
 			<return type="Color" />
-			<argument index="0" name="arg0" type="int" />
+			<param index="0" name="_unnamed_arg0" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="set_color">
 			<return type="void" />
-			<argument index="0" name="color" type="int" />
-			<argument index="1" name="arg1" type="Color" />
+			<param index="0" name="color" type="int" />
+			<param index="1" name="_unnamed_arg1" type="Color" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelGenerator.xml
+++ b/doc/classes/VoxelGenerator.xml
@@ -10,9 +10,9 @@
 	<methods>
 		<method name="generate_block">
 			<return type="void" />
-			<argument index="0" name="out_buffer" type="VoxelBuffer" />
-			<argument index="1" name="origin_in_voxels" type="Vector3" />
-			<argument index="2" name="lod" type="int" />
+			<param index="0" name="out_buffer" type="VoxelBuffer" />
+			<param index="1" name="origin_in_voxels" type="Vector3" />
+			<param index="2" name="lod" type="int" />
 			<description>
 				Generates a block of voxels within the specified world area.
 				[code]out_buffer[/code]: Buffer in which voxel data will be generated. It should not be [code]null[/code] and should be given the requested size. Do not keep a reference on it after the call.

--- a/doc/classes/VoxelGeneratorGraph.xml
+++ b/doc/classes/VoxelGeneratorGraph.xml
@@ -13,36 +13,36 @@
 	<methods>
 		<method name="add_connection">
 			<return type="void" />
-			<argument index="0" name="src_node_id" type="int" />
-			<argument index="1" name="src_port_index" type="int" />
-			<argument index="2" name="dst_node_id" type="int" />
-			<argument index="3" name="dst_port_index" type="int" />
+			<param index="0" name="src_node_id" type="int" />
+			<param index="1" name="src_port_index" type="int" />
+			<param index="2" name="dst_node_id" type="int" />
+			<param index="3" name="dst_port_index" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="bake_sphere_bumpmap">
 			<return type="void" />
-			<argument index="0" name="im" type="Image" />
-			<argument index="1" name="ref_radius" type="float" />
-			<argument index="2" name="sdf_min" type="float" />
-			<argument index="3" name="sdf_max" type="float" />
+			<param index="0" name="im" type="Image" />
+			<param index="1" name="ref_radius" type="float" />
+			<param index="2" name="sdf_min" type="float" />
+			<param index="3" name="sdf_max" type="float" />
 			<description>
 			</description>
 		</method>
 		<method name="bake_sphere_normalmap">
 			<return type="void" />
-			<argument index="0" name="im" type="Image" />
-			<argument index="1" name="ref_radius" type="float" />
-			<argument index="2" name="strength" type="float" />
+			<param index="0" name="im" type="Image" />
+			<param index="1" name="ref_radius" type="float" />
+			<param index="2" name="strength" type="float" />
 			<description>
 			</description>
 		</method>
 		<method name="can_connect" qualifiers="const">
 			<return type="bool" />
-			<argument index="0" name="src_node_id" type="int" />
-			<argument index="1" name="src_port_index" type="int" />
-			<argument index="2" name="dst_node_id" type="int" />
-			<argument index="3" name="dst_port_index" type="int" />
+			<param index="0" name="src_node_id" type="int" />
+			<param index="1" name="src_port_index" type="int" />
+			<param index="2" name="dst_node_id" type="int" />
+			<param index="3" name="dst_port_index" type="int" />
 			<description>
 				Tests if two ports can be connected together.
 			</description>
@@ -76,9 +76,9 @@
 		</method>
 		<method name="create_node">
 			<return type="int" />
-			<argument index="0" name="type_id" type="int" enum="VoxelGeneratorGraph.NodeTypeID" />
-			<argument index="1" name="position" type="Vector2" />
-			<argument index="2" name="id" type="int" default="0" />
+			<param index="0" name="type_id" type="int" enum="VoxelGeneratorGraph.NodeTypeID" />
+			<param index="1" name="position" type="Vector2" />
+			<param index="2" name="id" type="int" default="0" />
 			<description>
 				Creates a graph node of a given type at a specific visual position. That position does not affect how the graph will perform, however it helps organizing nodes.
 				An optional ID can be specified. If left to 0, the ID will be generated.
@@ -87,8 +87,8 @@
 		</method>
 		<method name="debug_analyze_range" qualifiers="const">
 			<return type="Vector2" />
-			<argument index="0" name="min_pos" type="Vector3" />
-			<argument index="1" name="max_pos" type="Vector3" />
+			<param index="0" name="min_pos" type="Vector3" />
+			<param index="1" name="max_pos" type="Vector3" />
 			<description>
 			</description>
 		</method>
@@ -99,13 +99,13 @@
 		</method>
 		<method name="debug_measure_microseconds_per_voxel">
 			<return type="float" />
-			<argument index="0" name="use_singular_queries" type="bool" />
+			<param index="0" name="use_singular_queries" type="bool" />
 			<description>
 			</description>
 		</method>
 		<method name="find_node_by_name" qualifiers="const">
 			<return type="int" />
-			<argument index="0" name="name" type="StringName" />
+			<param index="0" name="name" type="StringName" />
 			<description>
 			</description>
 		</method>
@@ -121,20 +121,20 @@
 		</method>
 		<method name="get_node_default_input" qualifiers="const">
 			<return type="Variant" />
-			<argument index="0" name="node_id" type="int" />
-			<argument index="1" name="input_index" type="int" />
+			<param index="0" name="node_id" type="int" />
+			<param index="1" name="input_index" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="get_node_default_inputs_autoconnect" qualifiers="const">
 			<return type="bool" />
-			<argument index="0" name="node_id" type="int" />
+			<param index="0" name="node_id" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="get_node_gui_position" qualifiers="const">
 			<return type="Vector2" />
-			<argument index="0" name="node_id" type="int" />
+			<param index="0" name="node_id" type="int" />
 			<description>
 			</description>
 		</method>
@@ -145,14 +145,14 @@
 		</method>
 		<method name="get_node_name" qualifiers="const">
 			<return type="StringName" />
-			<argument index="0" name="node_id" type="int" />
+			<param index="0" name="node_id" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="get_node_param" qualifiers="const">
 			<return type="Variant" />
-			<argument index="0" name="node_id" type="int" />
-			<argument index="1" name="param_index" type="int" />
+			<param index="0" name="node_id" type="int" />
+			<param index="1" name="param_index" type="int" />
 			<description>
 			</description>
 		</method>
@@ -163,79 +163,79 @@
 		</method>
 		<method name="get_node_type_id" qualifiers="const">
 			<return type="int" enum="VoxelGeneratorGraph.NodeTypeID" />
-			<argument index="0" name="node_id" type="int" />
+			<param index="0" name="node_id" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="get_node_type_info" qualifiers="const">
 			<return type="Dictionary" />
-			<argument index="0" name="type_id" type="int" />
+			<param index="0" name="type_id" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="remove_connection">
 			<return type="void" />
-			<argument index="0" name="src_node_id" type="int" />
-			<argument index="1" name="src_port_index" type="int" />
-			<argument index="2" name="dst_node_id" type="int" />
-			<argument index="3" name="dst_port_index" type="int" />
+			<param index="0" name="src_node_id" type="int" />
+			<param index="1" name="src_port_index" type="int" />
+			<param index="2" name="dst_node_id" type="int" />
+			<param index="3" name="dst_port_index" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="remove_node">
 			<return type="void" />
-			<argument index="0" name="node_id" type="int" />
+			<param index="0" name="node_id" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="set_expression_node_inputs">
 			<return type="void" />
-			<argument index="0" name="node_id" type="int" />
-			<argument index="1" name="names" type="PackedStringArray" />
+			<param index="0" name="node_id" type="int" />
+			<param index="1" name="names" type="PackedStringArray" />
 			<description>
 			</description>
 		</method>
 		<method name="set_node_default_input">
 			<return type="void" />
-			<argument index="0" name="node_id" type="int" />
-			<argument index="1" name="input_index" type="int" />
-			<argument index="2" name="value" type="Variant" />
+			<param index="0" name="node_id" type="int" />
+			<param index="1" name="input_index" type="int" />
+			<param index="2" name="value" type="Variant" />
 			<description>
 			</description>
 		</method>
 		<method name="set_node_default_inputs_autoconnect">
 			<return type="void" />
-			<argument index="0" name="node_id" type="int" />
-			<argument index="1" name="enabled" type="bool" />
+			<param index="0" name="node_id" type="int" />
+			<param index="1" name="enabled" type="bool" />
 			<description>
 			</description>
 		</method>
 		<method name="set_node_gui_position">
 			<return type="void" />
-			<argument index="0" name="node_id" type="int" />
-			<argument index="1" name="position" type="Vector2" />
+			<param index="0" name="node_id" type="int" />
+			<param index="1" name="position" type="Vector2" />
 			<description>
 			</description>
 		</method>
 		<method name="set_node_name">
 			<return type="void" />
-			<argument index="0" name="node_id" type="int" />
-			<argument index="1" name="name" type="StringName" />
+			<param index="0" name="node_id" type="int" />
+			<param index="1" name="name" type="StringName" />
 			<description>
 			</description>
 		</method>
 		<method name="set_node_param">
 			<return type="void" />
-			<argument index="0" name="node_id" type="int" />
-			<argument index="1" name="param_index" type="int" />
-			<argument index="2" name="value" type="Variant" />
+			<param index="0" name="node_id" type="int" />
+			<param index="1" name="param_index" type="int" />
+			<param index="2" name="value" type="Variant" />
 			<description>
 			</description>
 		</method>
 		<method name="set_node_param_null">
 			<return type="void" />
-			<argument index="0" name="node_id" type="int" />
-			<argument index="1" name="param_index" type="int" />
+			<param index="0" name="node_id" type="int" />
+			<param index="1" name="param_index" type="int" />
 			<description>
 			</description>
 		</method>
@@ -256,7 +256,7 @@
 	</members>
 	<signals>
 		<signal name="node_name_changed">
-			<argument index="0" name="node_id" type="int" />
+			<param index="0" name="node_id" type="int" />
 			<description>
 			</description>
 		</signal>
@@ -356,7 +356,9 @@
 		</constant>
 		<constant name="NODE_POW" value="48" enum="NodeTypeID">
 		</constant>
-		<constant name="NODE_TYPE_COUNT" value="49" enum="NodeTypeID">
+		<constant name="NODE_INPUT_SDF" value="49" enum="NodeTypeID">
+		</constant>
+		<constant name="NODE_TYPE_COUNT" value="50" enum="NodeTypeID">
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/VoxelGeneratorHeightmap.xml
+++ b/doc/classes/VoxelGeneratorHeightmap.xml
@@ -16,7 +16,7 @@
 		<member name="height_start" type="float" setter="set_height_start" getter="get_height_start" default="-50.0">
 			Minimum height where the surface will generate.
 		</member>
-		<member name="iso_scale" type="float" setter="set_iso_scale" getter="get_iso_scale" default="0.1">
+		<member name="iso_scale" type="float" setter="set_iso_scale" getter="get_iso_scale" default="0.002">
 			Scale applied to the signed distance field. This is useful when smooth voxels are used, to reduce blockyness over large distances.
 		</member>
 	</members>

--- a/doc/classes/VoxelGeneratorScript.xml
+++ b/doc/classes/VoxelGeneratorScript.xml
@@ -11,9 +11,9 @@
 	<methods>
 		<method name="_generate_block" qualifiers="virtual">
 			<return type="void" />
-			<argument index="0" name="out_buffer" type="VoxelBuffer" />
-			<argument index="1" name="origin_in_voxels" type="Vector3i" />
-			<argument index="2" name="lod" type="int" />
+			<param index="0" name="out_buffer" type="VoxelBuffer" />
+			<param index="1" name="origin_in_voxels" type="Vector3i" />
+			<param index="2" name="lod" type="int" />
 			<description>
 				[code]out_buffer[/code]: Buffer in which to populate voxel data. It will never be [code]null[/code] and will have the requested size. It is only valid for this function, do not store it anywhere after the end.
 				[code]origin_in_voxels[/code]: Coordinates of the lower corner of the box to generate, relative to LOD0. The size of the box is known from [code]out_buffer[/code].

--- a/doc/classes/VoxelInstanceGenerator.xml
+++ b/doc/classes/VoxelInstanceGenerator.xml
@@ -14,7 +14,7 @@
 			Controls how many instances are generated. Might give different results depending on the type of emission chosen.
 		</member>
 		<member name="emit_mode" type="int" setter="set_emit_mode" getter="get_emit_mode" enum="VoxelInstanceGenerator.EmitMode" default="0">
-			In which way instances are primarily emitted. 
+			In which way instances are primarily emitted.
 		</member>
 		<member name="max_height" type="float" setter="set_max_height" getter="get_max_height" default="3.40282e+38">
 			Instances will not be created above this height.
@@ -57,7 +57,7 @@
 			When enabled, instances will randomly be flipped upside down. This can be useful with small rocks to create illusion of more variety.
 		</member>
 		<member name="scale_distribution" type="int" setter="set_scale_distribution" getter="get_scale_distribution" enum="VoxelInstanceGenerator.Distribution" default="1">
-			Sets how random scales are distributed. 
+			Sets how random scales are distributed.
 		</member>
 		<member name="vertical_alignment" type="float" setter="set_vertical_alignment" getter="get_vertical_alignment" default="1.0">
 			Sets how much instances will align with the ground.

--- a/doc/classes/VoxelInstanceLibrary.xml
+++ b/doc/classes/VoxelInstanceLibrary.xml
@@ -10,8 +10,8 @@
 	<methods>
 		<method name="add_item">
 			<return type="void" />
-			<argument index="0" name="id" type="int" />
-			<argument index="1" name="arg1" type="VoxelInstanceLibraryItem" />
+			<param index="0" name="id" type="int" />
+			<param index="1" name="_unnamed_arg1" type="VoxelInstanceLibraryItem" />
 			<description>
 			</description>
 		</method>
@@ -22,19 +22,19 @@
 		</method>
 		<method name="find_item_by_name" qualifiers="const">
 			<return type="int" />
-			<argument index="0" name="name" type="String" />
+			<param index="0" name="name" type="String" />
 			<description>
 			</description>
 		</method>
 		<method name="get_item" qualifiers="const">
 			<return type="VoxelInstanceLibraryItem" />
-			<argument index="0" name="id" type="int" />
+			<param index="0" name="id" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="remove_item">
 			<return type="void" />
-			<argument index="0" name="id" type="int" />
+			<param index="0" name="id" type="int" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelInstanceLibraryMultiMeshItem.xml
+++ b/doc/classes/VoxelInstanceLibraryMultiMeshItem.xml
@@ -9,20 +9,20 @@
 	<methods>
 		<method name="get_mesh" qualifiers="const">
 			<return type="Mesh" />
-			<argument index="0" name="mesh_lod_index" type="int" />
+			<param index="0" name="mesh_lod_index" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="set_mesh">
 			<return type="void" />
-			<argument index="0" name="mesh" type="Mesh" />
-			<argument index="1" name="mesh_lod_index" type="int" />
+			<param index="0" name="mesh" type="Mesh" />
+			<param index="1" name="mesh_lod_index" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="setup_from_template">
 			<return type="void" />
-			<argument index="0" name="node" type="Node" />
+			<param index="0" name="node" type="Node" />
 			<description>
 			</description>
 		</method>
@@ -45,6 +45,8 @@
 		<member name="mesh_lod2" type="Mesh" setter="_set_mesh_lod2" getter="_get_mesh_lod2">
 		</member>
 		<member name="mesh_lod3" type="Mesh" setter="_set_mesh_lod3" getter="_get_mesh_lod3">
+		</member>
+		<member name="scene" type="PackedScene" setter="set_scene" getter="get_scene">
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VoxelInstancer.xml
+++ b/doc/classes/VoxelInstancer.xml
@@ -11,7 +11,7 @@
 	<methods>
 		<method name="debug_dump_as_scene" qualifiers="const">
 			<return type="void" />
-			<argument index="0" name="fpath" type="String" />
+			<param index="0" name="fpath" type="String" />
 			<description>
 			</description>
 		</method>
@@ -22,7 +22,7 @@
 		</method>
 		<method name="debug_get_draw_flag" qualifiers="const">
 			<return type="bool" />
-			<argument index="0" name="flag" type="int" enum="VoxelInstancer.DebugDrawFlag" />
+			<param index="0" name="flag" type="int" enum="VoxelInstancer.DebugDrawFlag" />
 			<description>
 			</description>
 		</method>
@@ -38,14 +38,14 @@
 		</method>
 		<method name="debug_set_draw_enabled">
 			<return type="void" />
-			<argument index="0" name="enabled" type="bool" />
+			<param index="0" name="enabled" type="bool" />
 			<description>
 			</description>
 		</method>
 		<method name="debug_set_draw_flag">
 			<return type="void" />
-			<argument index="0" name="flag" type="int" enum="VoxelInstancer.DebugDrawFlag" />
-			<argument index="1" name="enabled" type="bool" />
+			<param index="0" name="flag" type="int" enum="VoxelInstancer.DebugDrawFlag" />
+			<param index="1" name="enabled" type="bool" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelLodTerrain.xml
+++ b/doc/classes/VoxelLodTerrain.xml
@@ -10,8 +10,8 @@
 	<methods>
 		<method name="debug_dump_as_scene" qualifiers="const">
 			<return type="int" enum="Error" />
-			<argument index="0" name="path" type="String" />
-			<argument index="1" name="include_instancer" type="bool" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="include_instancer" type="bool" />
 			<description>
 			</description>
 		</method>
@@ -22,14 +22,14 @@
 		</method>
 		<method name="debug_get_data_block_info" qualifiers="const">
 			<return type="Dictionary" />
-			<argument index="0" name="block_pos" type="Vector3" />
-			<argument index="1" name="lod" type="int" />
+			<param index="0" name="block_pos" type="Vector3" />
+			<param index="1" name="lod" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="debug_get_draw_flag" qualifiers="const">
 			<return type="bool" />
-			<argument index="0" name="flag_index" type="int" enum="VoxelLodTerrain.DebugDrawFlag" />
+			<param index="0" name="flag_index" type="int" enum="VoxelLodTerrain.DebugDrawFlag" />
 			<description>
 			</description>
 		</method>
@@ -40,8 +40,8 @@
 		</method>
 		<method name="debug_get_mesh_block_info" qualifiers="const">
 			<return type="Dictionary" />
-			<argument index="0" name="block_pos" type="Vector3" />
-			<argument index="1" name="lod" type="int" />
+			<param index="0" name="block_pos" type="Vector3" />
+			<param index="1" name="lod" type="int" />
 			<description>
 			</description>
 		</method>
@@ -57,28 +57,28 @@
 		</method>
 		<method name="debug_print_sdf_top_down">
 			<return type="Array" />
-			<argument index="0" name="center" type="Vector3i" />
-			<argument index="1" name="extents" type="Vector3i" />
+			<param index="0" name="center" type="Vector3i" />
+			<param index="1" name="extents" type="Vector3i" />
 			<description>
 			</description>
 		</method>
 		<method name="debug_raycast_mesh_block" qualifiers="const">
 			<return type="Array" />
-			<argument index="0" name="origin" type="Vector3" />
-			<argument index="1" name="dir" type="Vector3" />
+			<param index="0" name="origin" type="Vector3" />
+			<param index="1" name="dir" type="Vector3" />
 			<description>
 			</description>
 		</method>
 		<method name="debug_set_draw_enabled">
 			<return type="void" />
-			<argument index="0" name="enabled" type="bool" />
+			<param index="0" name="enabled" type="bool" />
 			<description>
 			</description>
 		</method>
 		<method name="debug_set_draw_flag">
 			<return type="void" />
-			<argument index="0" name="flag_index" type="int" enum="VoxelLodTerrain.DebugDrawFlag" />
-			<argument index="1" name="enabled" type="bool" />
+			<param index="0" name="flag_index" type="int" enum="VoxelLodTerrain.DebugDrawFlag" />
+			<param index="1" name="enabled" type="bool" />
 			<description>
 			</description>
 		</method>
@@ -130,21 +130,21 @@
 		</method>
 		<method name="set_process_callback">
 			<return type="void" />
-			<argument index="0" name="mode" type="int" enum="VoxelLodTerrain.ProcessCallback" />
+			<param index="0" name="mode" type="int" enum="VoxelLodTerrain.ProcessCallback" />
 			<description>
 			</description>
 		</method>
 		<method name="voxel_to_data_block_position" qualifiers="const">
 			<return type="Vector3i" />
-			<argument index="0" name="lod_index" type="Vector3" />
-			<argument index="1" name="arg1" type="int" />
+			<param index="0" name="lod_index" type="Vector3" />
+			<param index="1" name="_unnamed_arg1" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="voxel_to_mesh_block_position" qualifiers="const">
 			<return type="Vector3i" />
-			<argument index="0" name="lod_index" type="Vector3" />
-			<argument index="1" name="arg1" type="int" />
+			<param index="0" name="lod_index" type="Vector3" />
+			<param index="1" name="_unnamed_arg1" type="int" />
 			<description>
 			</description>
 		</method>
@@ -173,6 +173,16 @@
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 		</member>
 		<member name="mesh_block_size" type="int" setter="set_mesh_block_size" getter="get_mesh_block_size" default="16">
+		</member>
+		<member name="normalmap_begin_lod_index" type="int" setter="set_normalmap_begin_lod_index" getter="get_normalmap_begin_lod_index" default="2">
+		</member>
+		<member name="normalmap_enabled" type="bool" setter="set_normalmap_enabled" getter="is_normalmap_enabled" default="false">
+		</member>
+		<member name="normalmap_octahedral_encoding_enabled" type="bool" setter="set_octahedral_normal_encoding" getter="get_octahedral_normal_encoding" default="false">
+		</member>
+		<member name="normalmap_tile_resolution_max" type="int" setter="set_normalmap_tile_resolution_max" getter="get_normalmap_tile_resolution_max" default="8">
+		</member>
+		<member name="normalmap_tile_resolution_min" type="int" setter="set_normalmap_tile_resolution_min" getter="get_normalmap_tile_resolution_min" default="4">
 		</member>
 		<member name="run_stream_in_editor" type="bool" setter="set_run_stream_in_editor" getter="is_stream_running_in_editor" default="true">
 		</member>

--- a/doc/classes/VoxelMeshSDF.xml
+++ b/doc/classes/VoxelMeshSDF.xml
@@ -14,13 +14,13 @@
 		</method>
 		<method name="bake_async">
 			<return type="void" />
-			<argument index="0" name="scene_tree" type="SceneTree" />
+			<param index="0" name="scene_tree" type="SceneTree" />
 			<description>
 			</description>
 		</method>
 		<method name="debug_check_sdf">
 			<return type="Array" />
-			<argument index="0" name="mesh" type="Mesh" />
+			<param index="0" name="mesh" type="Mesh" />
 			<description>
 			</description>
 		</method>
@@ -31,6 +31,16 @@
 		</method>
 		<method name="get_voxel_buffer" qualifiers="const">
 			<return type="VoxelBuffer" />
+			<description>
+			</description>
+		</method>
+		<method name="is_baked" qualifiers="const">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="is_baking" qualifiers="const">
+			<return type="bool" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelMesher.xml
+++ b/doc/classes/VoxelMesher.xml
@@ -11,8 +11,9 @@
 	<methods>
 		<method name="build_mesh">
 			<return type="Mesh" />
-			<argument index="0" name="voxel_buffer" type="VoxelBuffer" />
-			<argument index="1" name="materials" type="Material[]" />
+			<param index="0" name="voxel_buffer" type="VoxelBuffer" />
+			<param index="1" name="materials" type="Material[]" />
+			<param index="2" name="additional_data" type="Dictionary" default="{}" />
 			<description>
 				Builds a mesh from the provided voxels. Materials will be attached to each surface based on the provided array. The way materials are used can depend on the type of mesher.
 			</description>

--- a/doc/classes/VoxelMesherCubes.xml
+++ b/doc/classes/VoxelMesherCubes.xml
@@ -9,8 +9,8 @@
 	<methods>
 		<method name="set_material_by_index">
 			<return type="void" />
-			<argument index="0" name="id" type="int" enum="VoxelMesherCubes.Materials" />
-			<argument index="1" name="material" type="Material" />
+			<param index="0" name="id" type="int" enum="VoxelMesherCubes.Materials" />
+			<param index="1" name="material" type="Material" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelMesherDMC.xml
+++ b/doc/classes/VoxelMesherDMC.xml
@@ -20,7 +20,7 @@
 		</method>
 		<method name="set_geometric_error">
 			<return type="void" />
-			<argument index="0" name="error" type="float" />
+			<param index="0" name="error" type="float" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelMesherTransvoxel.xml
+++ b/doc/classes/VoxelMesherTransvoxel.xml
@@ -10,8 +10,8 @@
 	<methods>
 		<method name="build_transition_mesh">
 			<return type="ArrayMesh" />
-			<argument index="0" name="voxel_buffer" type="VoxelBuffer" />
-			<argument index="1" name="direction" type="int" />
+			<param index="0" name="voxel_buffer" type="VoxelBuffer" />
+			<param index="1" name="direction" type="int" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelNode.xml
+++ b/doc/classes/VoxelNode.xml
@@ -20,4 +20,12 @@
 			Primary source of persistent voxel data. If left unassigned, the whole volume will use the generator.
 		</member>
 	</members>
+	<constants>
+		<constant name="GI_MODE_DISABLED" value="0" enum="GIMode">
+		</constant>
+		<constant name="GI_MODE_BAKED" value="1" enum="GIMode">
+		</constant>
+		<constant name="GI_MODE_DYNAMIC" value="2" enum="GIMode">
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/VoxelStream.xml
+++ b/doc/classes/VoxelStream.xml
@@ -10,9 +10,9 @@
 	<methods>
 		<method name="emerge_block">
 			<return type="int" enum="VoxelStream.ResultCode" />
-			<argument index="0" name="out_buffer" type="VoxelBuffer" />
-			<argument index="1" name="origin_in_voxels" type="Vector3" />
-			<argument index="2" name="lod" type="int" />
+			<param index="0" name="out_buffer" type="VoxelBuffer" />
+			<param index="1" name="origin_in_voxels" type="Vector3" />
+			<param index="2" name="lod" type="int" />
 			<description>
 			</description>
 		</method>
@@ -28,26 +28,26 @@
 		</method>
 		<method name="immerge_block">
 			<return type="void" />
-			<argument index="0" name="buffer" type="VoxelBuffer" />
-			<argument index="1" name="origin_in_voxels" type="Vector3" />
-			<argument index="2" name="lod" type="int" />
+			<param index="0" name="buffer" type="VoxelBuffer" />
+			<param index="1" name="origin_in_voxels" type="Vector3" />
+			<param index="2" name="lod" type="int" />
 			<description>
 				[code]buffer[/code]: Block of voxels to save. It is strongly recommended to not keep a reference to that data afterward, because streams are allowed to cache it, and saved data must represent either snapshots (copies) or last references to the data after the volume they belonged to is destroyed.
 			</description>
 		</method>
 		<method name="load_voxel_block">
 			<return type="int" enum="VoxelStream.ResultCode" />
-			<argument index="0" name="out_buffer" type="VoxelBuffer" />
-			<argument index="1" name="origin_in_voxels" type="Vector3i" />
-			<argument index="2" name="lod" type="int" />
+			<param index="0" name="out_buffer" type="VoxelBuffer" />
+			<param index="1" name="origin_in_voxels" type="Vector3i" />
+			<param index="2" name="lod" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="save_voxel_block">
 			<return type="void" />
-			<argument index="0" name="buffer" type="VoxelBuffer" />
-			<argument index="1" name="origin_in_voxels" type="Vector3i" />
-			<argument index="2" name="lod" type="int" />
+			<param index="0" name="buffer" type="VoxelBuffer" />
+			<param index="1" name="origin_in_voxels" type="Vector3i" />
+			<param index="2" name="lod" type="int" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelStreamRegionFiles.xml
+++ b/doc/classes/VoxelStreamRegionFiles.xml
@@ -12,7 +12,7 @@
 	<methods>
 		<method name="convert_files">
 			<return type="void" />
-			<argument index="0" name="new_settings" type="Dictionary" />
+			<param index="0" name="new_settings" type="Dictionary" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelStreamSQLite.xml
+++ b/doc/classes/VoxelStreamSQLite.xml
@@ -15,7 +15,7 @@
 		</method>
 		<method name="set_key_cache_enabled">
 			<return type="void" />
-			<argument index="0" name="enabled" type="bool" />
+			<param index="0" name="enabled" type="bool" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelStreamScript.xml
+++ b/doc/classes/VoxelStreamScript.xml
@@ -15,17 +15,17 @@
 		</method>
 		<method name="_load_voxel_block" qualifiers="virtual">
 			<return type="int" />
-			<argument index="0" name="out_buffer" type="VoxelBuffer" />
-			<argument index="1" name="origin_in_voxels" type="Vector3i" />
-			<argument index="2" name="lod" type="int" />
+			<param index="0" name="out_buffer" type="VoxelBuffer" />
+			<param index="1" name="origin_in_voxels" type="Vector3i" />
+			<param index="2" name="lod" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="_save_voxel_block" qualifiers="virtual">
 			<return type="void" />
-			<argument index="0" name="buffer" type="VoxelBuffer" />
-			<argument index="1" name="origin_in_voxels" type="Vector3i" />
-			<argument index="2" name="lod" type="int" />
+			<param index="0" name="buffer" type="VoxelBuffer" />
+			<param index="1" name="origin_in_voxels" type="Vector3i" />
+			<param index="2" name="lod" type="int" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelTerrain.xml
+++ b/doc/classes/VoxelTerrain.xml
@@ -10,20 +10,20 @@
 	<methods>
 		<method name="_on_area_edited" qualifiers="virtual">
 			<return type="void" />
-			<argument index="0" name="area_origin" type="Vector3i" />
-			<argument index="1" name="area_size" type="Vector3i" />
+			<param index="0" name="area_origin" type="Vector3i" />
+			<param index="1" name="area_size" type="Vector3i" />
 			<description>
 			</description>
 		</method>
 		<method name="_on_data_block_entered" qualifiers="virtual">
 			<return type="void" />
-			<argument index="0" name="info" type="VoxelDataBlockEnterInfo" />
+			<param index="0" name="info" type="VoxelDataBlockEnterInfo" />
 			<description>
 			</description>
 		</method>
 		<method name="data_block_to_voxel" qualifiers="const">
 			<return type="Vector3i" />
-			<argument index="0" name="block_pos" type="Vector3i" />
+			<param index="0" name="block_pos" type="Vector3i" />
 			<description>
 				Converts data block coordinates into voxel coordinates. Voxel coordinates of a block correspond to its lowest corner.
 			</description>
@@ -55,8 +55,8 @@
 		</method>
 		<method name="get_viewer_network_peer_ids_in_area" qualifiers="const">
 			<return type="PackedInt32Array" />
-			<argument index="0" name="area_origin" type="Vector3i" />
-			<argument index="1" name="area_size" type="Vector3i" />
+			<param index="0" name="area_origin" type="Vector3i" />
+			<param index="1" name="area_size" type="Vector3i" />
 			<description>
 			</description>
 		</method>
@@ -69,13 +69,13 @@
 		</method>
 		<method name="has_data_block" qualifiers="const">
 			<return type="bool" />
-			<argument index="0" name="block_position" type="Vector3i" />
+			<param index="0" name="block_position" type="Vector3i" />
 			<description>
 			</description>
 		</method>
 		<method name="save_block">
 			<return type="void" />
-			<argument index="0" name="position" type="Vector3i" />
+			<param index="0" name="position" type="Vector3i" />
 			<description>
 				Forces a specific block to be saved.
 				Note 1: all modified blocks are automatically saved before the terrain is destroyed.
@@ -94,14 +94,14 @@
 		</method>
 		<method name="try_set_block_data">
 			<return type="bool" />
-			<argument index="0" name="position" type="Vector3i" />
-			<argument index="1" name="voxels" type="VoxelBuffer" />
+			<param index="0" name="position" type="Vector3i" />
+			<param index="1" name="voxels" type="VoxelBuffer" />
 			<description>
 			</description>
 		</method>
 		<method name="voxel_to_data_block" qualifiers="const">
 			<return type="Vector3i" />
-			<argument index="0" name="voxel_pos" type="Vector3" />
+			<param index="0" name="voxel_pos" type="Vector3" />
 			<description>
 			</description>
 		</method>
@@ -142,14 +142,14 @@
 	</members>
 	<signals>
 		<signal name="block_loaded">
-			<argument index="0" name="position" type="Vector3" />
+			<param index="0" name="position" type="Vector3" />
 			<description>
 				Emitted when a new data block is loaded from stream.
 				Note: it might be not visible yet.
 			</description>
 		</signal>
 		<signal name="block_unloaded">
-			<argument index="0" name="position" type="Vector3" />
+			<param index="0" name="position" type="Vector3" />
 			<description>
 				Emitted when a data block is unloaded due to being outside view distance.
 			</description>

--- a/doc/classes/VoxelTool.xml
+++ b/doc/classes/VoxelTool.xml
@@ -12,99 +12,99 @@
 	<methods>
 		<method name="color_to_u16" qualifiers="static">
 			<return type="int" />
-			<argument index="0" name="color" type="Color" />
+			<param index="0" name="color" type="Color" />
 			<description>
 			</description>
 		</method>
 		<method name="copy">
 			<return type="void" />
-			<argument index="0" name="src_pos" type="Vector3i" />
-			<argument index="1" name="dst_buffer" type="VoxelBuffer" />
-			<argument index="2" name="channels_mask" type="int" />
+			<param index="0" name="src_pos" type="Vector3i" />
+			<param index="1" name="dst_buffer" type="VoxelBuffer" />
+			<param index="2" name="channels_mask" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="do_box">
 			<return type="void" />
-			<argument index="0" name="begin" type="Vector3i" />
-			<argument index="1" name="end" type="Vector3i" />
+			<param index="0" name="begin" type="Vector3i" />
+			<param index="1" name="end" type="Vector3i" />
 			<description>
 				Operate on a rectangular cuboid section of the terrain. [code]begin[/code] and [code]end[/code] are inclusive. Choose operation and which voxel to use by setting [code]value[/code] and [code]mode[/code] before calling this function.
 			</description>
 		</method>
 		<method name="do_point">
 			<return type="void" />
-			<argument index="0" name="pos" type="Vector3i" />
+			<param index="0" name="pos" type="Vector3i" />
 			<description>
 			</description>
 		</method>
 		<method name="do_sphere">
 			<return type="void" />
-			<argument index="0" name="center" type="Vector3" />
-			<argument index="1" name="radius" type="float" />
+			<param index="0" name="center" type="Vector3" />
+			<param index="1" name="radius" type="float" />
 			<description>
 			</description>
 		</method>
 		<method name="get_voxel">
 			<return type="int" />
-			<argument index="0" name="pos" type="Vector3i" />
+			<param index="0" name="pos" type="Vector3i" />
 			<description>
 			</description>
 		</method>
 		<method name="get_voxel_f">
 			<return type="float" />
-			<argument index="0" name="pos" type="Vector3i" />
+			<param index="0" name="pos" type="Vector3i" />
 			<description>
 			</description>
 		</method>
 		<method name="get_voxel_metadata" qualifiers="const">
 			<return type="Variant" />
-			<argument index="0" name="pos" type="Vector3i" />
+			<param index="0" name="pos" type="Vector3i" />
 			<description>
 			</description>
 		</method>
 		<method name="is_area_editable" qualifiers="const">
 			<return type="bool" />
-			<argument index="0" name="box" type="AABB" />
+			<param index="0" name="box" type="AABB" />
 			<description>
 			</description>
 		</method>
 		<method name="paste">
 			<return type="void" />
-			<argument index="0" name="dst_pos" type="Vector3i" />
-			<argument index="1" name="src_buffer" type="VoxelBuffer" />
-			<argument index="2" name="channels_mask" type="int" />
-			<argument index="3" name="src_mask_value" type="int" />
+			<param index="0" name="dst_pos" type="Vector3i" />
+			<param index="1" name="src_buffer" type="VoxelBuffer" />
+			<param index="2" name="channels_mask" type="int" />
+			<param index="3" name="src_mask_value" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="raycast">
 			<return type="VoxelRaycastResult" />
-			<argument index="0" name="origin" type="Vector3" />
-			<argument index="1" name="direction" type="Vector3" />
-			<argument index="2" name="max_distance" type="float" default="10.0" />
-			<argument index="3" name="collision_mask" type="int" default="4294967295" />
+			<param index="0" name="origin" type="Vector3" />
+			<param index="1" name="direction" type="Vector3" />
+			<param index="2" name="max_distance" type="float" default="10.0" />
+			<param index="3" name="collision_mask" type="int" default="4294967295" />
 			<description>
 			</description>
 		</method>
 		<method name="set_voxel">
 			<return type="void" />
-			<argument index="0" name="pos" type="Vector3i" />
-			<argument index="1" name="v" type="int" />
+			<param index="0" name="pos" type="Vector3i" />
+			<param index="1" name="v" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="set_voxel_f">
 			<return type="void" />
-			<argument index="0" name="pos" type="Vector3i" />
-			<argument index="1" name="v" type="float" />
+			<param index="0" name="pos" type="Vector3i" />
+			<param index="1" name="v" type="float" />
 			<description>
 			</description>
 		</method>
 		<method name="set_voxel_metadata">
 			<return type="void" />
-			<argument index="0" name="pos" type="Vector3i" />
-			<argument index="1" name="meta" type="Variant" />
+			<param index="0" name="pos" type="Vector3i" />
+			<param index="1" name="meta" type="Variant" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelToolLodTerrain.xml
+++ b/doc/classes/VoxelToolLodTerrain.xml
@@ -9,19 +9,27 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="do_graph">
+			<return type="void" />
+			<param index="0" name="graph" type="VoxelGeneratorGraph" />
+			<param index="1" name="transform" type="Transform3D" />
+			<param index="2" name="area_size" type="Vector3" />
+			<description>
+			</description>
+		</method>
 		<method name="do_hemisphere">
 			<return type="void" />
-			<argument index="0" name="center" type="Vector3" />
-			<argument index="1" name="radius" type="float" />
-			<argument index="2" name="flat_direction" type="Vector3" />
-			<argument index="3" name="smoothness" type="float" default="0.0" />
+			<param index="0" name="center" type="Vector3" />
+			<param index="1" name="radius" type="float" />
+			<param index="2" name="flat_direction" type="Vector3" />
+			<param index="3" name="smoothness" type="float" default="0.0" />
 			<description>
 			</description>
 		</method>
 		<method name="do_sphere_async">
 			<return type="void" />
-			<argument index="0" name="center" type="Vector3" />
-			<argument index="1" name="radius" type="float" />
+			<param index="0" name="center" type="Vector3" />
+			<param index="1" name="radius" type="float" />
 			<description>
 			</description>
 		</method>
@@ -32,14 +40,14 @@
 		</method>
 		<method name="get_voxel_f_interpolated" qualifiers="const">
 			<return type="float" />
-			<argument index="0" name="position" type="Vector3" />
+			<param index="0" name="position" type="Vector3" />
 			<description>
 			</description>
 		</method>
 		<method name="separate_floating_chunks">
 			<return type="Array" />
-			<argument index="0" name="box" type="AABB" />
-			<argument index="1" name="parent_node" type="Node" />
+			<param index="0" name="box" type="AABB" />
+			<param index="1" name="parent_node" type="Node" />
 			<description>
 				Turns floating voxels into RigidBodies.
 				Chunks of floating voxels are detected within a box. The box is relative to the voxel volume this VoxelTool is attached to. Chunks have to be contained entirely within that box to be considered floating. Chunks are removed from the source volume and transformed into RigidBodies with convex collision shapes. They will be added as child of the provided node. They will start "kinematic", and turn "rigid" after a short time, to allow the terrain to update its colliders after the removal (otherwise they will overlap). The function returns an array of these rigid bodies, which you can use to attach further behavior to them (such as disappearing after some time or distance for example).
@@ -48,16 +56,16 @@
 		</method>
 		<method name="set_raycast_binary_search_iterations">
 			<return type="void" />
-			<argument index="0" name="iterations" type="int" />
+			<param index="0" name="iterations" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="stamp_sdf">
 			<return type="void" />
-			<argument index="0" name="mesh_sdf" type="VoxelMeshSDF" />
-			<argument index="1" name="transform" type="Transform3D" />
-			<argument index="2" name="isolevel" type="float" />
-			<argument index="3" name="sdf_scale" type="float" />
+			<param index="0" name="mesh_sdf" type="VoxelMeshSDF" />
+			<param index="1" name="transform" type="Transform3D" />
+			<param index="2" name="isolevel" type="float" />
+			<param index="3" name="sdf_scale" type="float" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelToolTerrain.xml
+++ b/doc/classes/VoxelToolTerrain.xml
@@ -11,17 +11,17 @@
 	<methods>
 		<method name="do_hemisphere">
 			<return type="void" />
-			<argument index="0" name="center" type="Vector3" />
-			<argument index="1" name="radius" type="float" />
-			<argument index="2" name="flat_direction" type="Vector3" />
-			<argument index="3" name="smoothness" type="float" default="0.0" />
+			<param index="0" name="center" type="Vector3" />
+			<param index="1" name="radius" type="float" />
+			<param index="2" name="flat_direction" type="Vector3" />
+			<param index="3" name="smoothness" type="float" default="0.0" />
 			<description>
 			</description>
 		</method>
 		<method name="for_each_voxel_metadata_in_area">
 			<return type="void" />
-			<argument index="0" name="voxel_area" type="AABB" />
-			<argument index="1" name="callback" type="Callable" />
+			<param index="0" name="voxel_area" type="AABB" />
+			<param index="1" name="callback" type="Callable" />
 			<description>
 				Executes a function for each voxel holding metadata in the given area.
 				The given callback takes two arguments: voxel position (Vector3i), voxel metadata (Variant).
@@ -30,10 +30,10 @@
 		</method>
 		<method name="run_blocky_random_tick" qualifiers="const">
 			<return type="void" />
-			<argument index="0" name="area" type="AABB" />
-			<argument index="1" name="voxel_count" type="int" />
-			<argument index="2" name="callback" type="Callable" />
-			<argument index="3" name="batch_count" type="int" default="16" />
+			<param index="0" name="area" type="AABB" />
+			<param index="1" name="voxel_count" type="int" />
+			<param index="2" name="callback" type="Callable" />
+			<param index="3" name="batch_count" type="int" default="16" />
 			<description>
 				Picks random voxels within the specified area and executes a function on them. This only works for terrains using [VoxelMesherBlocky]. Only voxels where [member Voxel.random_tickable] is [code]true[/code] will be picked.
 				The given callback takes two arguments: voxel position (Vector3i), voxel value (int).

--- a/doc/classes/VoxelViewer.xml
+++ b/doc/classes/VoxelViewer.xml
@@ -17,7 +17,7 @@
 		</method>
 		<method name="set_network_peer_id">
 			<return type="void" />
-			<argument index="0" name="id" type="int" />
+			<param index="0" name="id" type="int" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelVoxLoader.xml
+++ b/doc/classes/VoxelVoxLoader.xml
@@ -9,9 +9,9 @@
 	<methods>
 		<method name="load_from_file">
 			<return type="int" enum="Error" />
-			<argument index="0" name="fpath" type="String" />
-			<argument index="1" name="voxels" type="VoxelBuffer" />
-			<argument index="2" name="arg2" type="VoxelColorPalette" />
+			<param index="0" name="fpath" type="String" />
+			<param index="1" name="voxels" type="VoxelBuffer" />
+			<param index="2" name="_unnamed_arg2" type="VoxelColorPalette" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/ZN_FastNoiseLite.xml
+++ b/doc/classes/ZN_FastNoiseLite.xml
@@ -10,28 +10,28 @@
 	<methods>
 		<method name="get_noise_2d">
 			<return type="float" />
-			<argument index="0" name="x" type="float" />
-			<argument index="1" name="y" type="float" />
+			<param index="0" name="x" type="float" />
+			<param index="1" name="y" type="float" />
 			<description>
 			</description>
 		</method>
 		<method name="get_noise_2dv">
 			<return type="float" />
-			<argument index="0" name="position" type="Vector2" />
+			<param index="0" name="position" type="Vector2" />
 			<description>
 			</description>
 		</method>
 		<method name="get_noise_3d">
 			<return type="float" />
-			<argument index="0" name="x" type="float" />
-			<argument index="1" name="y" type="float" />
-			<argument index="2" name="z" type="float" />
+			<param index="0" name="x" type="float" />
+			<param index="1" name="y" type="float" />
+			<param index="2" name="z" type="float" />
 			<description>
 			</description>
 		</method>
 		<method name="get_noise_3dv">
 			<return type="float" />
-			<argument index="0" name="position" type="Vector3" />
+			<param index="0" name="position" type="Vector3" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/ZN_FastNoiseLiteGradient.xml
+++ b/doc/classes/ZN_FastNoiseLiteGradient.xml
@@ -10,13 +10,13 @@
 	<methods>
 		<method name="warp_2d">
 			<return type="Vector2" />
-			<argument index="0" name="position" type="Vector2" />
+			<param index="0" name="position" type="Vector2" />
 			<description>
 			</description>
 		</method>
 		<method name="warp_3d">
 			<return type="Vector3" />
-			<argument index="0" name="position" type="Vector3" />
+			<param index="0" name="position" type="Vector3" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/ZN_ThreadedTask.xml
+++ b/doc/classes/ZN_ThreadedTask.xml
@@ -19,7 +19,7 @@
 		</method>
 		<method name="_run" qualifiers="virtual">
 			<return type="void" />
-			<argument index="0" name="thread_index" type="int" />
+			<param index="0" name="thread_index" type="int" />
 			<description>
 			</description>
 		</method>


### PR DESCRIPTION
In the XML docs, the "argument" tag was renamed to "param". This PR runs doctool to update this. Running doctool also added and removed a few things from the XML docs. The parameter descriptions in `VoxelBlockyLibrary.xml` was not valid since parameter documentation is currently not supported in Godot's documentation XML.