### PR TITLE
Misc fixes to includes and build system

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -126,12 +126,6 @@ jobs:
           PATH=${GITHUB_WORKSPACE}/x86_64-godot-linux-gnu_sdk-buildroot/bin:$PATH
           scons -j2 verbose=yes warnings=all werror=yes platform=linuxbsd tests=no dev_build=${{matrix.dev_build}} dev_mode=yes target=${{matrix.target}} production=${{matrix.production}} float=${{matrix.float}}
 
-      # TODO Such tests are able to run from Godot 4.0 only
-      # Execute unit tests for the editor
-      #- name: Unit Tests
-      #  run: |
-      #    ./bin/godot.linuxbsd.opt.tools.64 --test
-
       # Make build available
       - uses: actions/upload-artifact@v2
         if: ${{ matrix.dev_build != 'yes' }}

--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -163,12 +163,6 @@ jobs:
         run: |
           scons -j2 verbose=yes warnings=all werror=yes platform=linuxbsd tests=no target=editor dev_build=no debug_symbols=no module_mono_enabled=yes mono_glue=yes mono_static=yes copy_mono_root=yes
 
-      # TODO Such tests are able to run from Godot 4.0 only
-      # Execute unit tests for the editor
-      #- name: Unit Tests
-      #  run: |
-      #    ./bin/godot.linuxbsd.opt.tools.x86_64.mono --test
-
       # Make build available
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -84,12 +84,6 @@ jobs:
         run: |
           scons -j2 verbose=yes warnings=all werror=yes platform=windows tests=no target=${{matrix.target}} dev_build=no
 
-      # TODO Such tests are able to run from Godot 4.0 only
-      # Execute unit tests for the editor
-      #- name: Unit Tests
-      #  run: |
-      #    ./bin/godot.windows.opt.tools.64.exe --test
-
       # Make build available
       - uses: actions/upload-artifact@v2
         with:

--- a/doc/source/module_development.md
+++ b/doc/source/module_development.md
@@ -209,8 +209,8 @@ Example of options setup in in VSCode `launch.json` on Windows:
             "type": "cppvsdbg", // For MSVC
             //"type": "cppdbg", // For GDB
             "request": "launch",
-            "program": "${workspaceFolder}/bin/godot.windows.tools.64.exe", // debug
-            //"program": "${workspaceFolder}/bin/godot.windows.opt.tools.64.exe", // release_debug
+            "program": "${workspaceFolder}/bin/godot.windows.editor.dev.x86_64.exe", // Dev build (old target=debug)
+            //"program": "${workspaceFolder}/bin/godot.windows.editor.x86_64.exe", // Non-dev build (old target=release_debug)
             "args": [
                 "-v", // Verbose output
                 

--- a/doc/tools/build.py
+++ b/doc/tools/build.py
@@ -20,6 +20,7 @@ import subprocess
 import getopt
 import glob
 import os
+import platform
 from pathlib import Path
 
 SOURCES = "source"
@@ -50,24 +51,30 @@ def update_classes_xml(custom_godot_path, godot_repo_root, verbose=False):
 
 def find_godot(bindir):
     # Match a filename like these
-    # godot.windows.tools.64.exe
-    # godot.x11.tools.64
-    #regex = r"godot\.(windows|x11|osx)(\.opt)?(\.tools)?\.(32|64)(\.exe)?"
+    # godot.windows.editor.dev.x86_64.exe
+    # godot.linuxbsd.editor.dev.x86_64
+    #regex = r"godot\.(windows|macos|linuxbsd)\.editor(\.dev)?\.(x86_32|x86_64|arm64|rv64)(\.exe)?"
     prefix = "godot"
+    os = ""
     suffix = ""
     if sys.platform == "win32" or sys.platform == "cygwin":
-        prefix += ".windows"
+        os = ".windows"
         suffix = ".exe"
+    elif sys.platform == "darwin":
+        os = ".macos"
     else:
-        # TODO Mac OS?
-        prefix += ".x11"
+        os = ".linuxbsd"
 
-    bits = ".64"
+    arch = ".x86_64"
+    if platform.machine().lower() == "arm64":
+        arch = ".arm64"
+    if platform.machine().lower() == "riscv64":
+        arch = ".rv64"
 
     # Names to try by priority
     names = [
-        prefix + ".tools" + bits + suffix,
-        prefix + ".opt.tools" + bits + suffix
+        prefix + os + ".editor.dev" + arch + suffix,
+        prefix + os + ".editor" + arch + suffix,
     ]
 
     for name in names:

--- a/storage/funcs.cpp
+++ b/storage/funcs.cpp
@@ -1,5 +1,6 @@
 #include "funcs.h"
 #include "../util/math/box3i.h"
+#include <cstring>
 
 namespace zylann::voxel {
 

--- a/storage/voxel_buffer_internal.cpp
+++ b/storage/voxel_buffer_internal.cpp
@@ -9,6 +9,7 @@
 #include "../util/profiling.h"
 #include "../util/string_funcs.h"
 #include "voxel_buffer_internal.h"
+#include <cstring>
 
 namespace zylann::voxel {
 

--- a/util/godot/string.h
+++ b/util/godot/string.h
@@ -9,6 +9,7 @@ using namespace godot;
 #endif
 
 #include <iosfwd>
+#include <string>
 #include <string_view>
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
* Fixes to includes to make CI builds not compile with errors.
* Fix `find_godot` function in `doc/tools/build.py` and add support for macOS and other architectures (I didn't check if the whole script works but I did check that this specific file name logic and the regex is correct).
* Remove commented-out unit test running code in the workflows (the TODO comment was confusing and the file path is no longer correct, so remove and they can just be added back later if needed).