### PR TITLE
Fix compile error in GPU storage buffer pool debug print

### DIFF
--- a/engine/gpu_storage_buffer_pool.cpp
+++ b/engine/gpu_storage_buffer_pool.cpp
@@ -155,7 +155,8 @@ void GPUStorageBufferPool::debug_print() const {
 		}
 		const unsigned int block_size = _pool_sizes[i];
 		s += String("Pool[{0}] block size: {1}, pooled buffers: {2}, capacity: {3}\n")
-					 .format(varray(i, block_size, pool.buffers.size(), pool.buffers.capacity()));
+					 .format(varray(i, block_size, ZN_SIZE_T_TO_VARIANT(pool.buffers.size()),
+							 ZN_SIZE_T_TO_VARIANT(pool.buffers.capacity())));
 	}
 	s += "----";
 	print_line(s);


### PR DESCRIPTION
The return type of `pool.buffers.size()` has an ambiguous conversion to Variant, at least on Clang on macOS (since the CI succeeds for Windows and Linux I guess this may be a Clang or Mac specific issue).

This PR explicitly converts them to `int64_t` before using them in the Variant array. I used `int64_t` because that's the type Variant stores internally, so it's the least amount of casting, but the conversion would also work using `uint64_t` or `unsigned int` or any other type Variant is able to be constructed from.