### PR TITLE
Missing #include <cstdint> causes Linux build to fail.

### DIFF
--- a/util/slot_map.h
+++ b/util/slot_map.h
@@ -2,6 +2,7 @@
 #define ZN_SLOT_MAP_H
 
 #include "errors.h"
+#include <cstdint>
 #include <limits>
 #include <vector>
 


### PR DESCRIPTION
When building on Linux the compiler complains about cstdint not being include, which results in types such uint32_t and other not being defined. 

In file included from modules/voxel/terrain/../engine/ids.h:4,
                 from modules/voxel/terrain/voxel_node.h:4,
                 from modules/voxel/terrain/voxel_node.cpp:1:
modules/voxel/terrain/../engine/../util/slot_map.h:13:22: error: 'uint32_t' does not name a type
   13 |         static const uint32_t UNUSED_BIT = 1 << (8 * sizeof(TVersion) - 1);
      |                      ^~~~~~~~
modules/voxel/terrain/../engine/../util/slot_map.h:7:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    6 | #include <vector>
  +++ |+#include <cstdint>

This commit adds just that one line.
