### PR TITLE
Fix compiling with Godot's MouseButton mask bitfield changes (beta 11)

### DIFF
--- a/editor/graph/voxel_graph_editor.cpp
+++ b/editor/graph/voxel_graph_editor.cpp
@@ -844,7 +844,7 @@ void VoxelGraphEditor::_on_graph_node_preview_gui_input(Ref<InputEvent> event) {
 	if (mm.is_valid()) {
 		// Ctrl+Drag above any preview to pan around the area they render.
 		if (mm->is_command_or_control_pressed() &&
-				(mm->get_button_mask() & ZN_GODOT_MouseButton_MASK_MIDDLE) != ZN_GODOT_MouseButton_NONE) {
+				mm->get_button_mask().has_flag(ZN_GODOT_MouseButtonMask_MIDDLE)) {
 			const Vector2 rel = mm->get_relative();
 			set_preview_transform(_preview_offset - Vector2f(rel.x, -rel.y) * _preview_scale, _preview_scale);
 

--- a/util/godot/core/mouse_button.h
+++ b/util/godot/core/mouse_button.h
@@ -5,18 +5,18 @@
 #include <core/input/input_enums.h>
 
 #define ZN_GODOT_MouseButton_NONE MouseButton::NONE
-#define ZN_GODOT_MouseButton_MASK_MIDDLE MouseButton::MASK_MIDDLE
 #define ZN_GODOT_MouseButton_WHEEL_UP MouseButton::WHEEL_UP
 #define ZN_GODOT_MouseButton_WHEEL_DOWN MouseButton::WHEEL_DOWN
+#define ZN_GODOT_MouseButtonMask_MIDDLE MouseButtonMask::MIDDLE
 
 #elif defined(ZN_GODOT_EXTENSION)
 #include <godot_cpp/classes/global_constants.hpp>
 using namespace godot;
 
 #define ZN_GODOT_MouseButton_NONE MouseButton::MOUSE_BUTTON_NONE
-#define ZN_GODOT_MouseButton_MASK_MIDDLE MouseButton::MOUSE_BUTTON_MASK_MIDDLE
 #define ZN_GODOT_MouseButton_WHEEL_UP MouseButton::MOUSE_BUTTON_WHEEL_UP
 #define ZN_GODOT_MouseButton_WHEEL_DOWN MouseButton::MOUSE_BUTTON_WHEEL_DOWN
+#define ZN_GODOT_MouseButtonMask_MIDDLE MouseButtonMask::MOUSE_BUTTON_MASK_MIDDLE
 
 #endif
 


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/71045 for the engine and https://github.com/godotengine/godot-cpp/blob/master/gdextension/extension_api.json for GDExtension.

Should work in both the engine module and GDExtension but I only tested as an engine module.