### PR TITLE
Fix condition of ZN_ASSERT_RETURN_MSG:

### DIFF
--- a/engine/save_block_data_task.cpp
+++ b/engine/save_block_data_task.cpp
@@ -58,7 +58,7 @@ void SaveBlockDataTask::run(zylann::ThreadedTaskContext ctx) {
 
 	CRASH_COND(_stream_dependency == nullptr);
 	Ref<VoxelStream> stream = _stream_dependency->stream;
-	ZN_ASSERT_RETURN_MSG(stream.is_null(), "Save task was triggered without a stream, this is a bug");
+	ZN_ASSERT_RETURN_MSG(stream.is_valid(), "Save task was triggered without a stream, this is a bug");
 
 	if (_save_voxels) {
 		if (_voxels == nullptr) {


### PR DESCRIPTION
stream.is_null()→stream.is_valid()