### PR TITLE
Fix mono CI

### DIFF
--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -31,8 +31,7 @@ jobs:
       # Azure repositories are not reliable, we need to prevent azure giving us packages.
       - name: Make apt sources.list use the default Ubuntu repositories
         run: |
-          sudo rm -f /etc/apt/sources.list.d/*
-          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+          sudo add-apt-repository ppa:kisak/kisak-mesa
           sudo apt-get update
 
       # Install all packages (except scons)
@@ -110,8 +109,7 @@ jobs:
       # Azure repositories are not reliable, we need to prevent azure giving us packages.
       - name: Make apt sources.list use the default Ubuntu repositories
         run: |
-          sudo rm -f /etc/apt/sources.list.d/*
-          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+          sudo add-apt-repository ppa:kisak/kisak-mesa
           sudo apt-get update
 
       # Install all packages (except scons)


### PR DESCRIPTION
Fixes #354

On Feb 7 in commit [da124e9d](https://github.com/godotengine/godot/commit/da124e9d04b2cd3d7be43f5653a6ffb2747a1c4a), Godot changed its apt sources and deleted `misc/ci/sources.list` from the repo, which broke the godot_voxel mono builds.

Update `mono.yml` to reflect these changes made in godot's CI: https://github.com/godotengine/godot/commit/da124e9d04b2cd3d7be43f5653a6ffb2747a1c4a