### PR TITLE
Fix "Failed to load .NET runtime" in mono CI builds

### DIFF
--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Generate Mono Glue
         run: |
-          xvfb-run ./bin/godot.linuxbsd.editor.x86_64.mono --generate-mono-glue modules/mono/glue || true
+          xvfb-run ./bin/godot.linuxbsd.editor.x86_64.mono --headless --generate-mono-glue modules/mono/glue || true
 
       # Make glue available as artifact for dependent jobs
       - uses: actions/upload-artifact@v2
@@ -152,6 +152,10 @@ jobs:
           name: mono-glue
           path: modules/mono/glue
 
+      - name: Build the managed libraries
+        run: |
+          ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin
+
       # We should always be explicit with our flags usage here since it's gonna be sure to always set those flags
       - name: Compilation
         env:
@@ -186,11 +190,6 @@ jobs:
       # Move nuget.config from voxel repo to root of checkout, so msbuild can find it
       - name: Move nuget.config
         run: mv modules/voxel/nuget.config ./nuget.config
-
-      # Install mono
-      - name: Configure dependencies
-        run: |
-          choco install -y mono
 
       # Upload cache on completion and check it out now
       # Editing this is pretty dangerous for Windows since it can break and needs to be properly tested with a fresh cache.
@@ -228,6 +227,10 @@ jobs:
         with:
           name: mono-glue
           path: modules/mono/glue
+
+      - name: Build the managed libraries
+        run: |
+          python ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin
 
       # We should always be explicit with our flags usage here since it's gonna be sure to always set those flags
       - name: Compilation

--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -28,8 +28,7 @@ jobs:
         with:
           path: modules/voxel
 
-      # Azure repositories are not reliable, we need to prevent azure giving us packages.
-      - name: Make apt sources.list use the default Ubuntu repositories
+      - name: Install dependencies
         run: |
           sudo add-apt-repository ppa:kisak/kisak-mesa
           sudo apt-get update
@@ -106,8 +105,7 @@ jobs:
         with:
           path: modules/voxel
 
-      # Azure repositories are not reliable, we need to prevent azure giving us packages.
-      - name: Make apt sources.list use the default Ubuntu repositories
+      - name: Install dependencies
         run: |
           sudo add-apt-repository ppa:kisak/kisak-mesa
           sudo apt-get update


### PR DESCRIPTION
Builds [the managed libraries via build_assemblies.py](https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_with_dotnet.html#building-the-managed-libraries), which adds the `GodotSharp` directory, which fixes this error when starting the editor:
![image](https://user-images.githubusercontent.com/6390507/225679031-4ca936de-4679-4542-b5cc-65b46e515751.png)

(The official release doesn't need the `GodotSharp` directory & files, but I think that's just because they packaged it into the executable with fancier build actions)

Mono is no longer installed on the `Windows Editor w/ Mono` image since the "windows-latest" base comes with dotnet 6.0, which Godot 4 has switched to.

----

* I've added the same `build_assemblies.py` change to the mono-linux build, it builds successfully but I haven't tested the binaries as I don't have a non-remote linux box.
* On Windows, the Godot 4.1.dev Editor binaries built from this action can compile and run my dotnet 6.0 C#-based project. My project doesn't use godot_voxel yet but I can see that nodes like VoxelLodTerrain are available from the Add Node dialog, so for windows at least I believe these editor binaries are working!
* Export Templates are still not supported (the Mono Builds action didn't build them before and I've not attempted to).