### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/extension_windows.yml
+++ b/.github/workflows/extension_windows.yml
@@ -26,20 +26,20 @@ jobs:
           - name: Editor build
             target: editor
             dev_build: no
-            #cache_action: actions/cache@v2
+            #cache_action: actions/cache@v3
             executable_name: libvoxel.windows.editor.x86_64.dll
           - name: Release build
             target: template_release
             dev_build: no
-            #cache_action: actions/cache@v2
+            #cache_action: actions/cache@v3
             executable_name: libvoxel.windows.template_release.x86_64.dll
 
     steps:
       # Clone our repo
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Clone GodotCpp
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: godotengine/godot-cpp
           ref: master
@@ -50,7 +50,7 @@ jobs:
       - name: Load .scons_cache directory
         id: windows-editor-cache
         #uses: ${{matrix.cache_action}}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /.scons_cache/
           key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
@@ -61,7 +61,7 @@ jobs:
 
       # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.x'
@@ -87,7 +87,7 @@ jobs:
           dir
 
       # Make build available
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         #if: ${{ matrix.target == 'Editor' }}
         with:
           name: ${{matrix.executable_name}}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -44,13 +44,13 @@ jobs:
 
     steps:
       # Clone Godot
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: godotengine/godot
           ref: "4.0"
 
       # Clone our module under the correct directory
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: modules/voxel
 
@@ -91,7 +91,7 @@ jobs:
       # Upload cache on completion and check it out now
       - name: Load .scons_cache directory
         id: linux-editor-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{github.workspace}}/.scons_cache/
           key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
@@ -103,7 +103,7 @@ jobs:
       # [Already provided by the custom buildroot]
       # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
       # - name: Set up Python 3.x
-      #   uses: actions/setup-python@v2
+      #   uses: actions/setup-python@v4
       #   with:
       #     # Semantic version range syntax or exact version of a Python version
       #     python-version: '3.x'
@@ -128,7 +128,7 @@ jobs:
           scons -j2 verbose=yes warnings=extra werror=yes platform=linuxbsd tests=no dev_build=${{matrix.dev_build}} dev_mode=yes target=${{matrix.target}} production=${{matrix.production}} float=${{matrix.float}}
 
       # Make build available
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ matrix.dev_build != 'yes' }}
         with:
           name: ${{matrix.executable_name}}

--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       # Clone Godot
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: godotengine/godot
           ref: "4.0"
 
       # Clone our module under the correct directory
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: modules/voxel
 
@@ -42,7 +42,7 @@ jobs:
       # Upload cache on completion and check it out now
       - name: Load .scons_cache directory
         id: mono-glue-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{github.workspace}}/.scons_cache/
           key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
@@ -53,7 +53,7 @@ jobs:
 
       # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.x'
@@ -80,7 +80,7 @@ jobs:
           xvfb-run ./bin/godot.linuxbsd.editor.x86_64.mono --headless --generate-mono-glue modules/mono/glue || true
 
       # Make glue available as artifact for dependent jobs
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: mono-glue
           path: |
@@ -95,13 +95,13 @@ jobs:
 
     steps:
       # Clone Godot
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: godotengine/godot
           ref: "4.0"
 
       # Clone our module under the correct directory
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: modules/voxel
 
@@ -119,7 +119,7 @@ jobs:
       # Upload cache on completion and check it out now
       - name: Load .scons_cache directory
         id: linux-editor-mono-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{github.workspace}}/.scons_cache/
           key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
@@ -130,7 +130,7 @@ jobs:
 
       # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.x'
@@ -147,7 +147,7 @@ jobs:
 
       # Download glue from the mono-glue job
       - name: Download Glue
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: mono-glue
           path: modules/mono/glue
@@ -164,7 +164,7 @@ jobs:
           scons -j2 verbose=yes warnings=all werror=yes platform=linuxbsd tests=no target=editor dev_build=no debug_symbols=no module_mono_enabled=yes mono_glue=yes mono_static=yes copy_mono_root=yes
 
       # Make build available
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: godot.linuxbsd.editor.x86_64.mono
           path: bin/*
@@ -177,13 +177,13 @@ jobs:
 
     steps:
       # Clone Godot
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: godotengine/godot
           ref: "4.0"
 
       # Clone our module under the correct directory
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: modules/voxel
 
@@ -195,7 +195,7 @@ jobs:
       # Editing this is pretty dangerous for Windows since it can break and needs to be properly tested with a fresh cache.
       - name: Load .scons_cache directory
         id: windows-editor-mono-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /.scons_cache/
           key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
@@ -206,7 +206,7 @@ jobs:
 
       # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.x'
@@ -223,7 +223,7 @@ jobs:
 
       # Download glue from the mono-glue job
       - name: Download Glue
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: mono-glue
           path: modules/mono/glue
@@ -247,7 +247,7 @@ jobs:
       #    ./bin/godot.windows.editor.x86_64.mono.exe --test
 
       # Make build available
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: godot.windows.editor.x86_64.mono
           path: bin/*

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,7 @@ jobs:
         include:
           - name: Editor build
             target: editor
-            #cache_action: actions/cache@v2
+            #cache_action: actions/cache@v3
             executable_name: godot.windows.editor.x86_64.exe
 
           - name: Release build
@@ -36,13 +36,13 @@ jobs:
 
     steps:
       # Clone Godot
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: godotengine/godot
           ref: "4.0"
 
       # Clone our module under the correct directory
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: modules/voxel
 
@@ -51,7 +51,7 @@ jobs:
       - name: Load .scons_cache directory
         id: windows-editor-cache
         #uses: ${{matrix.cache_action}}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /.scons_cache/
           key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
@@ -62,7 +62,7 @@ jobs:
 
       # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.x'
@@ -87,7 +87,7 @@ jobs:
           scons -j2 verbose=yes warnings=all werror=yes platform=windows tests=no target=${{matrix.target}} dev_build=no
 
       # Make build available
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{matrix.executable_name}}
           path: bin/${{matrix.executable_name}}


### PR DESCRIPTION
The following updates are performed:
* update [`actions/cache`](https://github.com/actions/cache) to v3
* update [`actions/checkout`](https://github.com/actions/checkout) to v3
* update [`actions/download-artifact`](https://github.com/actions/download-artifact) to v3
* update [`actions/setup-python`](https://github.com/actions/setup-python) to v4
* update [`actions/upload-artifact`](https://github.com/actions/upload-artifact) to v3

Still using the outdated actions will generate several warnings in CI runs, for example in https://github.com/Zylann/godot_voxel/actions/runs/5204696634:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/cache@v2, actions/setup-python@v2, actions/download-artifact@v2, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings.