### PR TITLE
Fix some clang complains

### DIFF
--- a/editor/fast_noise_2/chart_view.cpp
+++ b/editor/fast_noise_2/chart_view.cpp
@@ -63,7 +63,6 @@ void ChartView::_notification(int p_what) {
 }
 
 void ChartView::_draw() {
-	const Color bg_color(Color(0.15, 0.15, 0.15));
 	const Color line_color(Color(0.8, 0.8, 0.8, 1.0));
 	const Color x_axis_color(Color(1.0, 1.0, 1.0, 0.5));
 	const Color y_axis_color(Color(1.0, 1.0, 1.0, 0.5));

--- a/editor/fast_noise_2/fast_noise_2_editor_plugin.h
+++ b/editor/fast_noise_2/fast_noise_2_editor_plugin.h
@@ -12,7 +12,7 @@ class FastNoise2EditorPlugin : public EditorPlugin {
 public:
 	FastNoise2EditorPlugin();
 
-	virtual String get_name() const {
+	String get_name() const override {
 		return "FastNoise2";
 	}
 

--- a/generators/simple/voxel_generator_noise_2d.cpp
+++ b/generators/simple/voxel_generator_noise_2d.cpp
@@ -99,8 +99,6 @@ void VoxelGeneratorNoise2D::generate_series(Span<const float> positions_x, Span<
 		params = _parameters;
 	}
 
-	Result result;
-
 	ERR_FAIL_COND(params.noise.is_null());
 	Noise &noise = **params.noise;
 

--- a/meshers/blocky/voxel_blocky_model_mesh.cpp
+++ b/meshers/blocky/voxel_blocky_model_mesh.cpp
@@ -21,6 +21,7 @@ void VoxelBlockyModelMesh::set_mesh(Ref<Mesh> mesh) {
 	emit_changed();
 }
 
+#ifdef TOOLS_ENABLED
 // Generate tangents based on UVs (won't be as good as properly imported tangents)
 static PackedFloat32Array generate_tangents_from_uvs(const PackedVector3Array &positions,
 		const PackedVector3Array &normals, const PackedVector2Array &uvs, const PackedInt32Array &indices) {
@@ -56,6 +57,7 @@ static PackedFloat32Array generate_tangents_from_uvs(const PackedVector3Array &p
 
 	return tangents;
 }
+#endif
 
 static void add(Span<Vector3> vectors, Vector3 rhs) {
 	for (Vector3 &v : vectors) {

--- a/meshers/transvoxel/transvoxel_cell_iterator.h
+++ b/meshers/transvoxel/transvoxel_cell_iterator.h
@@ -42,7 +42,7 @@ public:
 		}
 	}
 
-	void rewind() {
+	void rewind() override {
 		_current_index = 0;
 		_triangle_begin_index = 0;
 	}

--- a/util/slot_map.h
+++ b/util/slot_map.h
@@ -93,9 +93,9 @@ public:
 			const TIndex i = _slots.size();
 			// Start versions at 1, so we can represent 0 as invalid
 			const uint32_t v = 1;
-			_slots.push_back(Slot{ value, v });
+			_slots.push_back(Slot{ value, {v} });
 			++_count;
-			return Key{ i, v };
+			return Key{ i, {v} };
 		}
 	}
 


### PR DESCRIPTION
Fixes some warnings like `inconsistent-missing-override` and `unused-variable/function`.

I'm not sure if the changes on `slot_map.h` are valid. Just submitting because this is the change requested and it managed to compile successfully.

Follow up for #534.

This does not fix **ALL** of them. However, I can tell where the remaining are:

```
modules/voxel/storage/voxel_data.cpp:469:23: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
                bbox.for_each_cell([this, &data_lod0, lod0_new_blocks_to_lod](Vector3i block_pos_lod0) {
                                    ^~~~~
modules/voxel/storage/voxel_data_map.cpp:68:14: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
        map_block = std::move(VoxelDataBlock(buffer, _lod_index));
                    ^
modules/voxel/storage/voxel_data_map.cpp:68:14: note: remove std::move call here
        map_block = std::move(VoxelDataBlock(buffer, _lod_index));
                    ^~~~~~~~~~                                  ~
modules/voxel/storage/voxel_data_map.cpp:133:15: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
                map_block = std::move(VoxelDataBlock(buffer, _lod_index));
                            ^
modules/voxel/storage/voxel_data_map.cpp:133:15: note: remove std::move call here
                map_block = std::move(VoxelDataBlock(buffer, _lod_index));
                            ^~~~~~~~~~                                  ~
modules/voxel/storage/voxel_data_map.cpp:160:15: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
                map_block = std::move(VoxelDataBlock(_lod_index));
                            ^
modules/voxel/storage/voxel_data_map.cpp:160:15: note: remove std::move call here
                map_block = std::move(VoxelDataBlock(_lod_index));
                            ^~~~~~~~~~                          ~
```