### PR TITLE
Update Minecraft wiki link to new domain

### DIFF
--- a/meshers/blocky/types/voxel_blocky_type.cpp
+++ b/meshers/blocky/types/voxel_blocky_type.cpp
@@ -20,7 +20,7 @@
 namespace zylann::voxel {
 
 // Making types can get quite complicated, config files sound like a better solution compared to messing around in the
-// inspector, see how Minecraft defines their models: https://minecraft.fandom.com/wiki/Tutorials/Models
+// inspector, see how Minecraft defines their models: https://minecraft.wiki/w/Tutorials/Models
 
 VoxelBlockyType::VoxelBlockyType() {
 	_name = VoxelStringNames::get_singleton().unnamed;


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.