### PR TITLE
Run doctool for Godot 4.2

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ def configure(env):
 
     env_vars = Variables()
 
-    env_vars.Add(BoolVariable("voxel_tests", 
+    env_vars.Add(BoolVariable("voxel_tests",
         "Build with tests for the voxel module, which will run on startup of the engine", False))
 
     env_vars.Add(BoolVariable("voxel_fast_noise_2", "Build FastNoise2 support (x86-only)", True))
@@ -30,15 +30,15 @@ def get_doc_classes():
         "VoxelBlockSerializer",
         "VoxelBlockyAttribute",
         "VoxelBlockyAttributeAxis",
+        "VoxelBlockyAttributeCustom",
         "VoxelBlockyAttributeDirection",
         "VoxelBlockyAttributeRotation",
-        "VoxelBlockyAttributeCustom",
         "VoxelBlockyLibrary",
         "VoxelBlockyLibraryBase",
         "VoxelBlockyModel",
-        "VoxelBlockyModelMesh",
         "VoxelBlockyModelCube",
         "VoxelBlockyModelEmpty",
+        "VoxelBlockyModelMesh",
         "VoxelBlockyType",
         "VoxelBlockyTypeLibrary",
         "VoxelBoxMover",
@@ -77,11 +77,13 @@ def get_doc_classes():
         "VoxelModifierSphere",
         "VoxelNode",
         "VoxelRaycastResult",
+        "VoxelSaveCompletionTracker",
         "VoxelStream",
         "VoxelStreamRegionFiles",
         "VoxelStreamScript",
         "VoxelStreamSQLite",
         "VoxelTerrain",
+        "VoxelTerrainMultiplayerSynchronizer",
         "VoxelTool",
         "VoxelToolBuffer",
         "VoxelToolLodTerrain",

--- a/doc/classes/VoxelAStarGrid3D.xml
+++ b/doc/classes/VoxelAStarGrid3D.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelAStarGrid3D" inherits="RefCounted" is_experimental="true" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelAStarGrid3D" inherits="RefCounted" is_experimental="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Grid-based A* pathfinding algorithm adapted to blocky voxel terrain.
 	</brief_description>

--- a/doc/classes/VoxelBlockSerializer.xml
+++ b/doc/classes/VoxelBlockSerializer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBlockSerializer" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBlockSerializer" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VoxelBlockyAttribute.xml
+++ b/doc/classes/VoxelBlockyAttribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBlockyAttribute" inherits="Resource" is_experimental="true" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBlockyAttribute" inherits="Resource" is_experimental="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VoxelBlockyAttributeAxis.xml
+++ b/doc/classes/VoxelBlockyAttributeAxis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBlockyAttributeAxis" inherits="VoxelBlockyAttribute" is_experimental="true" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBlockyAttributeAxis" inherits="VoxelBlockyAttribute" is_experimental="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VoxelBlockyAttributeCustom.xml
+++ b/doc/classes/VoxelBlockyAttributeCustom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBlockyAttributeCustom" inherits="VoxelBlockyAttribute" is_experimental="true" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBlockyAttributeCustom" inherits="VoxelBlockyAttribute" is_experimental="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VoxelBlockyAttributeDirection.xml
+++ b/doc/classes/VoxelBlockyAttributeDirection.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBlockyAttributeDirection" inherits="VoxelBlockyAttribute" is_experimental="true" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBlockyAttributeDirection" inherits="VoxelBlockyAttribute" is_experimental="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VoxelBlockyAttributeRotation.xml
+++ b/doc/classes/VoxelBlockyAttributeRotation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBlockyAttributeRotation" inherits="VoxelBlockyAttribute" is_experimental="true" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBlockyAttributeRotation" inherits="VoxelBlockyAttribute" is_experimental="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VoxelBlockyLibrary.xml
+++ b/doc/classes/VoxelBlockyLibrary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBlockyLibrary" inherits="VoxelBlockyLibraryBase" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBlockyLibrary" inherits="VoxelBlockyLibraryBase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Contains a list of models that can be used by [VoxelMesherBlocky].
 	</brief_description>

--- a/doc/classes/VoxelBlockyLibraryBase.xml
+++ b/doc/classes/VoxelBlockyLibraryBase.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBlockyLibraryBase" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBlockyLibraryBase" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Contains a list of models that can be used by [VoxelMesherBlocky].
 	</brief_description>

--- a/doc/classes/VoxelBlockyModel.xml
+++ b/doc/classes/VoxelBlockyModel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBlockyModel" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBlockyModel" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Model stored in [VoxelBlockyLibrary] and used by [VoxelMesherBlocky].
 	</brief_description>
@@ -26,8 +26,8 @@
 		</method>
 		<method name="rotate_90">
 			<return type="void" />
-			<param index="0" name="_unnamed_arg0" type="int" enum="Vector3i.Axis" />
-			<param index="1" name="_unnamed_arg1" type="bool" />
+			<param index="0" name="axis" type="int" enum="Vector3i.Axis" />
+			<param index="1" name="clockwise" type="bool" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/VoxelBlockyModelCube.xml
+++ b/doc/classes/VoxelBlockyModelCube.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBlockyModelCube" inherits="VoxelBlockyModel" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBlockyModelCube" inherits="VoxelBlockyModel" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Generates a cube model with specific tiles on its sides.
 	</brief_description>

--- a/doc/classes/VoxelBlockyModelEmpty.xml
+++ b/doc/classes/VoxelBlockyModelEmpty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBlockyModelEmpty" inherits="VoxelBlockyModel" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBlockyModelEmpty" inherits="VoxelBlockyModel" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Explicitely represents an empty model.
 	</brief_description>

--- a/doc/classes/VoxelBlockyModelMesh.xml
+++ b/doc/classes/VoxelBlockyModelMesh.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBlockyModelMesh" inherits="VoxelBlockyModel" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBlockyModelMesh" inherits="VoxelBlockyModel" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Generates a model based on a custom mesh.
 	</brief_description>

--- a/doc/classes/VoxelBlockyType.xml
+++ b/doc/classes/VoxelBlockyType.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBlockyType" inherits="Resource" is_experimental="true" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBlockyType" inherits="Resource" is_experimental="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VoxelBlockyTypeLibrary.xml
+++ b/doc/classes/VoxelBlockyTypeLibrary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBlockyTypeLibrary" inherits="VoxelBlockyLibraryBase" is_experimental="true" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBlockyTypeLibrary" inherits="VoxelBlockyLibraryBase" is_experimental="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VoxelBoxMover.xml
+++ b/doc/classes/VoxelBoxMover.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBoxMover" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBoxMover" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VoxelBuffer.xml
+++ b/doc/classes/VoxelBuffer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelBuffer" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelBuffer" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		3D grid storing voxel data.
 	</brief_description>

--- a/doc/classes/VoxelColorPalette.xml
+++ b/doc/classes/VoxelColorPalette.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelColorPalette" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelColorPalette" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Limited list of colors that can be indexed quickly.
 	</brief_description>

--- a/doc/classes/VoxelDataBlockEnterInfo.xml
+++ b/doc/classes/VoxelDataBlockEnterInfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelDataBlockEnterInfo" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelDataBlockEnterInfo" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Information sent by a terrain when one of its data blocks enters the area of a [VoxelViewer].
 	</brief_description>

--- a/doc/classes/VoxelEngine.xml
+++ b/doc/classes/VoxelEngine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelEngine" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelEngine" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Singleton holding common settings and handling voxel processing tasks in background threads.
 	</brief_description>

--- a/doc/classes/VoxelGenerator.xml
+++ b/doc/classes/VoxelGenerator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelGenerator" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelGenerator" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Base class to all voxel procedural generators.
 	</brief_description>

--- a/doc/classes/VoxelGeneratorFlat.xml
+++ b/doc/classes/VoxelGeneratorFlat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelGeneratorFlat" inherits="VoxelGenerator" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelGeneratorFlat" inherits="VoxelGenerator" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Voxel generator producing an infinite flat ground.
 	</brief_description>

--- a/doc/classes/VoxelGeneratorGraph.xml
+++ b/doc/classes/VoxelGeneratorGraph.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelGeneratorGraph" inherits="VoxelGenerator" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelGeneratorGraph" inherits="VoxelGenerator" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Graph-based voxel generator.
 	</brief_description>

--- a/doc/classes/VoxelGeneratorHeightmap.xml
+++ b/doc/classes/VoxelGeneratorHeightmap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelGeneratorHeightmap" inherits="VoxelGenerator" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelGeneratorHeightmap" inherits="VoxelGenerator" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VoxelGeneratorImage.xml
+++ b/doc/classes/VoxelGeneratorImage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelGeneratorImage" inherits="VoxelGeneratorHeightmap" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelGeneratorImage" inherits="VoxelGeneratorHeightmap" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Voxel generator producing a heightmap-based shape using an image.
 	</brief_description>

--- a/doc/classes/VoxelGeneratorMultipassCB.xml
+++ b/doc/classes/VoxelGeneratorMultipassCB.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelGeneratorMultipassCB" inherits="VoxelGenerator" is_experimental="true" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelGeneratorMultipassCB" inherits="VoxelGenerator" is_experimental="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Scriptable generator working on columns of blocks and multiple passes.
 	</brief_description>

--- a/doc/classes/VoxelGeneratorNoise.xml
+++ b/doc/classes/VoxelGeneratorNoise.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelGeneratorNoise" inherits="VoxelGenerator" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelGeneratorNoise" inherits="VoxelGenerator" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Voxel generator producing overhanging shapes using 3D noise.
 	</brief_description>

--- a/doc/classes/VoxelGeneratorNoise2D.xml
+++ b/doc/classes/VoxelGeneratorNoise2D.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelGeneratorNoise2D" inherits="VoxelGeneratorHeightmap" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelGeneratorNoise2D" inherits="VoxelGeneratorHeightmap" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Voxel generator producing noise-based heightmap terrain.
 	</brief_description>

--- a/doc/classes/VoxelGeneratorScript.xml
+++ b/doc/classes/VoxelGeneratorScript.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelGeneratorScript" inherits="VoxelGenerator" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelGeneratorScript" inherits="VoxelGenerator" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Base class for custom generators defined with a script.
 	</brief_description>

--- a/doc/classes/VoxelGeneratorWaves.xml
+++ b/doc/classes/VoxelGeneratorWaves.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelGeneratorWaves" inherits="VoxelGeneratorHeightmap" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelGeneratorWaves" inherits="VoxelGeneratorHeightmap" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Voxel generator producing a wavy terrain pattern.
 	</brief_description>

--- a/doc/classes/VoxelGraphFunction.xml
+++ b/doc/classes/VoxelGraphFunction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelGraphFunction" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelGraphFunction" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Graph for generating or processing voxels.
 	</brief_description>
@@ -252,9 +252,9 @@
 		</constant>
 		<constant name="NODE_OUTPUT_SDF" value="4" enum="NodeTypeID">
 		</constant>
-		<constant name="NODE_CUSTOM_INPUT" value="54" enum="NodeTypeID">
+		<constant name="NODE_CUSTOM_INPUT" value="52" enum="NodeTypeID">
 		</constant>
-		<constant name="NODE_CUSTOM_OUTPUT" value="55" enum="NodeTypeID">
+		<constant name="NODE_CUSTOM_OUTPUT" value="53" enum="NodeTypeID">
 		</constant>
 		<constant name="NODE_ADD" value="5" enum="NodeTypeID">
 		</constant>
@@ -332,31 +332,27 @@
 		</constant>
 		<constant name="NODE_OUTPUT_WEIGHT" value="43" enum="NodeTypeID">
 		</constant>
-		<constant name="NODE_FAST_NOISE_2_2D" value="45" enum="NodeTypeID">
+		<constant name="NODE_OUTPUT_SINGLE_TEXTURE" value="45" enum="NodeTypeID">
 		</constant>
-		<constant name="NODE_FAST_NOISE_2_3D" value="46" enum="NodeTypeID">
+		<constant name="NODE_EXPRESSION" value="46" enum="NodeTypeID">
 		</constant>
-		<constant name="NODE_OUTPUT_SINGLE_TEXTURE" value="47" enum="NodeTypeID">
+		<constant name="NODE_POWI" value="47" enum="NodeTypeID">
 		</constant>
-		<constant name="NODE_EXPRESSION" value="48" enum="NodeTypeID">
+		<constant name="NODE_POW" value="48" enum="NodeTypeID">
 		</constant>
-		<constant name="NODE_POWI" value="49" enum="NodeTypeID">
+		<constant name="NODE_INPUT_SDF" value="49" enum="NodeTypeID">
 		</constant>
-		<constant name="NODE_POW" value="50" enum="NodeTypeID">
+		<constant name="NODE_COMMENT" value="50" enum="NodeTypeID">
 		</constant>
-		<constant name="NODE_INPUT_SDF" value="51" enum="NodeTypeID">
+		<constant name="NODE_FUNCTION" value="51" enum="NodeTypeID">
 		</constant>
-		<constant name="NODE_COMMENT" value="52" enum="NodeTypeID">
+		<constant name="NODE_RELAY" value="54" enum="NodeTypeID">
 		</constant>
-		<constant name="NODE_FUNCTION" value="53" enum="NodeTypeID">
+		<constant name="NODE_SPOTS_2D" value="55" enum="NodeTypeID">
 		</constant>
-		<constant name="NODE_RELAY" value="56" enum="NodeTypeID">
+		<constant name="NODE_SPOTS_3D" value="56" enum="NodeTypeID">
 		</constant>
-		<constant name="NODE_SPOTS_2D" value="57" enum="NodeTypeID">
-		</constant>
-		<constant name="NODE_SPOTS_3D" value="58" enum="NodeTypeID">
-		</constant>
-		<constant name="NODE_TYPE_COUNT" value="59" enum="NodeTypeID">
+		<constant name="NODE_TYPE_COUNT" value="57" enum="NodeTypeID">
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/VoxelInstanceComponent.xml
+++ b/doc/classes/VoxelInstanceComponent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelInstanceComponent" inherits="Node" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelInstanceComponent" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		This node gets attached to scene items instanced by [VoxelInstancer].
 	</brief_description>

--- a/doc/classes/VoxelInstanceGenerator.xml
+++ b/doc/classes/VoxelInstanceGenerator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelInstanceGenerator" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelInstanceGenerator" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Decides where to spawn instances on top of a voxel surface.
 	</brief_description>

--- a/doc/classes/VoxelInstanceLibrary.xml
+++ b/doc/classes/VoxelInstanceLibrary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelInstanceLibrary" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelInstanceLibrary" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Contains a list of models that can be used by [VoxelInstancer], associated with a unique ID.
 	</brief_description>

--- a/doc/classes/VoxelInstanceLibraryItem.xml
+++ b/doc/classes/VoxelInstanceLibraryItem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelInstanceLibraryItem" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelInstanceLibraryItem" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Settings for a model that can be used by [VoxelInstancer]
 	</brief_description>

--- a/doc/classes/VoxelInstanceLibraryMultiMeshItem.xml
+++ b/doc/classes/VoxelInstanceLibraryMultiMeshItem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelInstanceLibraryMultiMeshItem" inherits="VoxelInstanceLibraryItem" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelInstanceLibraryMultiMeshItem" inherits="VoxelInstanceLibraryItem" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Instancer model using [MultiMesh] to render.
 	</brief_description>
@@ -43,6 +43,8 @@
 		</method>
 	</methods>
 	<members>
+		<member name="_mesh_lod_distance_ratios" type="PackedFloat32Array" setter="_set_mesh_lod_distance_ratios" getter="_get_mesh_lod_distance_ratios" default="PackedFloat32Array(0.2, 0.35, 0.6, 1)">
+		</member>
 		<member name="cast_shadow" type="int" setter="set_cast_shadows_setting" getter="get_cast_shadows_setting" enum="RenderingServer.ShadowCastingSetting" default="1">
 		</member>
 		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer" default="1">
@@ -51,15 +53,27 @@
 		</member>
 		<member name="collision_shapes" type="Array" setter="set_collision_shapes" getter="get_collision_shapes" default="[]">
 		</member>
+		<member name="gi_mode" type="int" setter="set_gi_mode" getter="get_gi_mode" enum="GeometryInstance3D.GIMode" default="1">
+		</member>
+		<member name="hide_beyond_max_lod" type="bool" setter="set_hide_beyond_max_lod" getter="get_hide_beyond_max_lod" default="false">
+		</member>
 		<member name="material_override" type="Material" setter="set_material_override" getter="get_material_override">
 		</member>
 		<member name="mesh" type="Mesh" setter="_set_mesh_lod0" getter="_get_mesh_lod0">
 		</member>
+		<member name="mesh_lod0_distance_ratio" type="float" setter="_set_mesh_lod0_distance_ratio" getter="_get_mesh_lod0_distance_ratio" default="0.2">
+		</member>
 		<member name="mesh_lod1" type="Mesh" setter="_set_mesh_lod1" getter="_get_mesh_lod1">
+		</member>
+		<member name="mesh_lod1_distance_ratio" type="float" setter="_set_mesh_lod1_distance_ratio" getter="_get_mesh_lod1_distance_ratio" default="0.35">
 		</member>
 		<member name="mesh_lod2" type="Mesh" setter="_set_mesh_lod2" getter="_get_mesh_lod2">
 		</member>
+		<member name="mesh_lod2_distance_ratio" type="float" setter="_set_mesh_lod2_distance_ratio" getter="_get_mesh_lod2_distance_ratio" default="0.6">
+		</member>
 		<member name="mesh_lod3" type="Mesh" setter="_set_mesh_lod3" getter="_get_mesh_lod3">
+		</member>
+		<member name="mesh_lod3_distance_ratio" type="float" setter="_set_mesh_lod3_distance_ratio" getter="_get_mesh_lod3_distance_ratio" default="1.0">
 		</member>
 		<member name="render_layer" type="int" setter="set_render_layer" getter="get_render_layer" default="1">
 		</member>

--- a/doc/classes/VoxelInstanceLibrarySceneItem.xml
+++ b/doc/classes/VoxelInstanceLibrarySceneItem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelInstanceLibrarySceneItem" inherits="VoxelInstanceLibraryItem" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelInstanceLibrarySceneItem" inherits="VoxelInstanceLibraryItem" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Instancer model using scenes.
 	</brief_description>

--- a/doc/classes/VoxelInstancer.xml
+++ b/doc/classes/VoxelInstancer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelInstancer" inherits="Node3D" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelInstancer" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Spawns items on top of voxel surfaces.
 	</brief_description>

--- a/doc/classes/VoxelInstancerRigidBody.xml
+++ b/doc/classes/VoxelInstancerRigidBody.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelInstancerRigidBody" inherits="RigidBody3D" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelInstancerRigidBody" inherits="RigidBody3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Collision node generated for every collidable multimesh instance created by [VoxelInstancer].
 	</brief_description>

--- a/doc/classes/VoxelLodTerrain.xml
+++ b/doc/classes/VoxelLodTerrain.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelLodTerrain" inherits="VoxelNode" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelLodTerrain" inherits="VoxelNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Voxel volume using variable level of detail.
 	</brief_description>

--- a/doc/classes/VoxelMeshSDF.xml
+++ b/doc/classes/VoxelMeshSDF.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelMeshSDF" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelMeshSDF" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VoxelMesher.xml
+++ b/doc/classes/VoxelMesher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelMesher" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelMesher" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Base class for all meshing algorithms.
 	</brief_description>

--- a/doc/classes/VoxelMesherBlocky.xml
+++ b/doc/classes/VoxelMesherBlocky.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelMesherBlocky" inherits="VoxelMesher" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelMesherBlocky" inherits="VoxelMesher" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Produces a mesh by batching models corresponding to each voxel value, similar to games like Minecraft or StarMade.
 	</brief_description>

--- a/doc/classes/VoxelMesherCubes.xml
+++ b/doc/classes/VoxelMesherCubes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelMesherCubes" inherits="VoxelMesher" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelMesherCubes" inherits="VoxelMesher" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VoxelMesherDMC.xml
+++ b/doc/classes/VoxelMesherDMC.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelMesherDMC" inherits="VoxelMesher" is_deprecated="true" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelMesherDMC" inherits="VoxelMesher" is_deprecated="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Implements isosurface generation (smooth voxels) using [url=https://www.volume-gfx.com/volume-rendering/dual-marching-cubes/]Dual Marching Cubes[/url].
 		[i]Deprecated.[/i] Use [VoxelMesherTransvoxel] instead.

--- a/doc/classes/VoxelMesherTransvoxel.xml
+++ b/doc/classes/VoxelMesherTransvoxel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelMesherTransvoxel" inherits="VoxelMesher" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelMesherTransvoxel" inherits="VoxelMesher" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Implements isosurface generation (smooth voxels) using the [url=https://transvoxel.org/]Transvoxel[/url] algorithm.
 	</brief_description>

--- a/doc/classes/VoxelModifier.xml
+++ b/doc/classes/VoxelModifier.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelModifier" inherits="Node3D" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelModifier" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VoxelModifierMesh.xml
+++ b/doc/classes/VoxelModifierMesh.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelModifierMesh" inherits="VoxelModifier" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelModifierMesh" inherits="VoxelModifier" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VoxelModifierSphere.xml
+++ b/doc/classes/VoxelModifierSphere.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelModifierSphere" inherits="VoxelModifier" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelModifierSphere" inherits="VoxelModifier" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/VoxelNode.xml
+++ b/doc/classes/VoxelNode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelNode" inherits="Node3D" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelNode" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Base class for voxel volumes.
 	</brief_description>
@@ -13,21 +13,15 @@
 		<member name="generator" type="VoxelGenerator" setter="set_generator" getter="get_generator">
 			Procedural generator used to load voxel blocks when not present in the stream.
 		</member>
-		<member name="gi_mode" type="int" setter="set_gi_mode" getter="get_gi_mode" enum="VoxelNode.GIMode" default="0">
+		<member name="gi_mode" type="int" setter="set_gi_mode" getter="get_gi_mode" enum="GeometryInstance3D.GIMode" default="0">
 		</member>
 		<member name="mesher" type="VoxelMesher" setter="set_mesher" getter="get_mesher">
 			Defines how voxels are transformed into visible meshes.
+		</member>
+		<member name="render_layers_mask" type="int" setter="set_render_layers_mask" getter="get_render_layers_mask" default="1">
 		</member>
 		<member name="stream" type="VoxelStream" setter="set_stream" getter="get_stream">
 			Primary source of persistent voxel data. If left unassigned, the whole volume will use the generator.
 		</member>
 	</members>
-	<constants>
-		<constant name="GI_MODE_DISABLED" value="0" enum="GIMode">
-		</constant>
-		<constant name="GI_MODE_BAKED" value="1" enum="GIMode">
-		</constant>
-		<constant name="GI_MODE_DYNAMIC" value="2" enum="GIMode">
-		</constant>
-	</constants>
 </class>

--- a/doc/classes/VoxelRaycastResult.xml
+++ b/doc/classes/VoxelRaycastResult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelRaycastResult" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelRaycastResult" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Result of a raycast performed with [method VoxelTool.raycast]
 	</brief_description>
@@ -8,7 +8,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="distance" type="float" setter="" getter="get_distance" default="-4.31602e+08">
+		<member name="distance" type="float" setter="" getter="get_distance" default="0.0">
 		</member>
 		<member name="position" type="Vector3i" setter="" getter="get_position" default="Vector3i(0, 0, 0)">
 			Integer position of the voxel that was hit.

--- a/doc/classes/VoxelSaveCompletionTracker.xml
+++ b/doc/classes/VoxelSaveCompletionTracker.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="VoxelSaveCompletionTracker" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_remaining_tasks" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_total_tasks" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="is_aborted" qualifiers="const">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="is_complete" qualifiers="const">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/VoxelStream.xml
+++ b/doc/classes/VoxelStream.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelStream" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelStream" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Implements loading and saving voxel blocks, mainly using files.
 	</brief_description>

--- a/doc/classes/VoxelStreamRegionFiles.xml
+++ b/doc/classes/VoxelStreamRegionFiles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelStreamRegionFiles" inherits="VoxelStream" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelStreamRegionFiles" inherits="VoxelStream" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Loads and saves blocks to region files indexed by world position, under a directory.
 	</brief_description>

--- a/doc/classes/VoxelStreamSQLite.xml
+++ b/doc/classes/VoxelStreamSQLite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelStreamSQLite" inherits="VoxelStream" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelStreamSQLite" inherits="VoxelStream" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Saves voxel data into a single SQLite database file.
 	</brief_description>

--- a/doc/classes/VoxelStreamScript.xml
+++ b/doc/classes/VoxelStreamScript.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelStreamScript" inherits="VoxelStream" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelStreamScript" inherits="VoxelStream" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Base class for custom streams defined with a script.
 	</brief_description>

--- a/doc/classes/VoxelTerrain.xml
+++ b/doc/classes/VoxelTerrain.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelTerrain" inherits="VoxelNode" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelTerrain" inherits="VoxelNode" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Voxel volume using constant level of detail.
 	</brief_description>

--- a/doc/classes/VoxelTerrainMultiplayerSynchronizer.xml
+++ b/doc/classes/VoxelTerrainMultiplayerSynchronizer.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="VoxelTerrainMultiplayerSynchronizer" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/VoxelTool.xml
+++ b/doc/classes/VoxelTool.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelTool" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelTool" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Helper class to easily access and modify voxels
 	</brief_description>
@@ -41,6 +41,13 @@
 			<param index="1" name="end" type="Vector3i" />
 			<description>
 				Operate on a rectangular cuboid section of the terrain. [code]begin[/code] and [code]end[/code] are inclusive. Choose operation and which voxel to use by setting [code]value[/code] and [code]mode[/code] before calling this function.
+			</description>
+		</method>
+		<method name="do_path">
+			<return type="void" />
+			<param index="0" name="points" type="PackedVector3Array" />
+			<param index="1" name="radii" type="PackedFloat32Array" />
+			<description>
 			</description>
 		</method>
 		<method name="do_point">

--- a/doc/classes/VoxelToolBuffer.xml
+++ b/doc/classes/VoxelToolBuffer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelToolBuffer" inherits="VoxelTool" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelToolBuffer" inherits="VoxelTool" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Implementation of the [VoxelTool] API for [VoxelBuffer].
 	</brief_description>

--- a/doc/classes/VoxelToolLodTerrain.xml
+++ b/doc/classes/VoxelToolLodTerrain.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelToolLodTerrain" inherits="VoxelTool" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelToolLodTerrain" inherits="VoxelTool" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Implementation of [VoxelTool] specialized for uses on [VoxelLodTerrain].
 	</brief_description>

--- a/doc/classes/VoxelToolMultipassGenerator.xml
+++ b/doc/classes/VoxelToolMultipassGenerator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelToolMultipassGenerator" inherits="VoxelTool" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelToolMultipassGenerator" inherits="VoxelTool" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Provided to edit voxels in the context of multipass terrain generation.
 	</brief_description>

--- a/doc/classes/VoxelToolTerrain.xml
+++ b/doc/classes/VoxelToolTerrain.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelToolTerrain" inherits="VoxelTool" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelToolTerrain" inherits="VoxelTool" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Implementation of [VoxelTool] specialized for uses on [VoxelTerrain].
 	</brief_description>

--- a/doc/classes/VoxelViewer.xml
+++ b/doc/classes/VoxelViewer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelViewer" inherits="Node3D" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelViewer" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Attach this as a child node of characters, so the voxel world will know where to load blocks around them.
 		If no viewer is present in the world, nothing will generate.

--- a/doc/classes/VoxelVoxLoader.xml
+++ b/doc/classes/VoxelVoxLoader.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VoxelVoxLoader" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="VoxelVoxLoader" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/ZN_FastNoiseLite.xml
+++ b/doc/classes/ZN_FastNoiseLite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="ZN_FastNoiseLite" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="ZN_FastNoiseLite" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Generates coherent and fractal noise using the [url=https://github.com/Auburn/FastNoiseLite]FastNoiseLite[/url] library.
 	</brief_description>

--- a/doc/classes/ZN_FastNoiseLiteGradient.xml
+++ b/doc/classes/ZN_FastNoiseLiteGradient.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="ZN_FastNoiseLiteGradient" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="ZN_FastNoiseLiteGradient" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Generates coherent and fractal noise gradients using the [url=https://github.com/Auburn/FastNoiseLite]FastNoiseLite[/url] library.
 	</brief_description>

--- a/doc/classes/ZN_ThreadedTask.xml
+++ b/doc/classes/ZN_ThreadedTask.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="ZN_ThreadedTask" inherits="RefCounted" is_experimental="true" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="ZN_ThreadedTask" inherits="RefCounted" is_experimental="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>


### PR DESCRIPTION
This PR runs the doctool for Godot 4.2, removing the `version=` property, and writing the recent API changes.