### PR TITLE
fix: fix broken builds because of godot physics files moved to another directory

### DIFF
--- a/util/godot/classes/collision_shape_3d.h
+++ b/util/godot/classes/collision_shape_3d.h
@@ -2,7 +2,14 @@
 #define ZN_GODOT_COLLISION_SHAPE_3D_H
 
 #if defined(ZN_GODOT)
+#include <core/version.h>
+
+#if VERSION_MAJOR == 4 && VERSION_MINOR <= 2
 #include <scene/3d/collision_shape_3d.h>
+#else
+#include <scene/3d/physics/collision_shape_3d.h>
+#endif
+
 #elif defined(ZN_GODOT_EXTENSION)
 #include <godot_cpp/classes/collision_shape3d.hpp>
 using namespace godot;

--- a/util/godot/classes/physics_body_3d.h
+++ b/util/godot/classes/physics_body_3d.h
@@ -2,7 +2,14 @@
 #define ZN_GODOT_PHYSICS_BODY_3D_H
 
 #if defined(ZN_GODOT)
+#include <core/version.h>
+
+#if VERSION_MAJOR == 4 && VERSION_MINOR <= 2
 #include <scene/3d/physics_body_3d.h>
+#else
+#include <scene/3d/physics/physics_body_3d.h>
+#endif
+
 #elif defined(ZN_GODOT_EXTENSION)
 #include <godot_cpp/classes/physics_body3d.hpp>
 using namespace godot;

--- a/util/godot/classes/rigid_body_3d.h
+++ b/util/godot/classes/rigid_body_3d.h
@@ -2,7 +2,14 @@
 #define ZN_GODOT_RIGID_BODY_3D_H
 
 #if defined(ZN_GODOT)
+#include <core/version.h>
+
+#if VERSION_MAJOR == 4 && VERSION_MINOR <= 2
 #include <scene/3d/physics_body_3d.h>
+#else
+#include <scene/3d/physics/rigid_body_3d.h>
+#endif
+
 #elif defined(ZN_GODOT_EXTENSION)
 #include <godot_cpp/classes/rigid_body3d.hpp>
 using namespace godot;


### PR DESCRIPTION
The title says it all, I've had problems building from source because the godot devs moved all physics related files to `scenes/3d/physics`.
