### PR TITLE
Small grow_sphere adjustments

### DIFF
--- a/doc/classes/VoxelTool.xml
+++ b/doc/classes/VoxelTool.xml
@@ -91,7 +91,7 @@
 				Adds/removes (depending on [code]mode[/code]) a value to/from all voxels within a sphere. Added/removed value will be equal to [code]strength[/code] at the center of the sphere, and decreases linearly to zero at the surface of the sphere. Voxels outside the sphere will not be affected.
 				[code]sphere_center[/code] is position in the terrain that will be smoothed out.
 				[code]sphere_radius[/code] radius of a sphere from the [code]center[/code] where voxel values will be affected. Should be greater than zero.
-				[code]strength[/code] value that controls maximal value that will be added/removed to/from voxels. Should be in range [0, 1]. Suggested to keep value same as [code]sdf_scale[/code].
+				[code]strength[/code] value that controls maximal value that will be added/removed to/from voxels. Suggested range is [0, 10].
 				Note 1: This is currently implemented only for terrain that uses SDF data (smooth voxels).
 				Note 2: This is meant to be analogous to Surface tool from Unreal Engine Voxel Plugin.
 			</description>

--- a/edition/voxel_tool.cpp
+++ b/edition/voxel_tool.cpp
@@ -319,7 +319,7 @@ void VoxelTool::grow_sphere(Vector3 sphere_center, float sphere_radius, float st
 	// see: https://github.com/Zylann/godot_voxel/pull/594
 	ZN_PROFILE_SCOPE();
 	ZN_ASSERT_RETURN(sphere_radius >= 0.01f);
-	ZN_ASSERT_RETURN(strength >= 0.0f && strength <= 1.0f);
+	ZN_ASSERT_RETURN(strength >= 0.0f && strength <= 10.0f);
 
 	const Box3i voxel_box = Box3i::from_min_max(
 			math::floor_to_int(sphere_center - Vector3(sphere_radius, sphere_radius, sphere_radius)),
@@ -341,7 +341,7 @@ void VoxelTool::grow_sphere(Vector3 sphere_center, float sphere_radius, float st
 		const Vector3f relative_sphere_center = to_vec3f(sphere_center - to_vec3(voxel_box.pos));
 		const float signed_strength = _mode == VoxelTool::MODE_REMOVE ? -strength : strength;
 
-		ops::grow_sphere(buffer, signed_strength, relative_sphere_center, sphere_radius);
+		ops::grow_sphere(buffer, _sdf_scale * signed_strength, relative_sphere_center, sphere_radius);
 
 		paste(voxel_box.pos, buffer, (1 << VoxelBuffer::CHANNEL_SDF));
 

--- a/edition/voxel_tool.cpp
+++ b/edition/voxel_tool.cpp
@@ -319,7 +319,6 @@ void VoxelTool::grow_sphere(Vector3 sphere_center, float sphere_radius, float st
 	// see: https://github.com/Zylann/godot_voxel/pull/594
 	ZN_PROFILE_SCOPE();
 	ZN_ASSERT_RETURN(sphere_radius >= 0.01f);
-	ZN_ASSERT_RETURN(strength >= 0.0f && strength <= 10.0f);
 
 	const Box3i voxel_box = Box3i::from_min_max(
 			math::floor_to_int(sphere_center - Vector3(sphere_radius, sphere_radius, sphere_radius)),


### PR DESCRIPTION
Changes:
- Fixed `grow_sphere` not using `sdf_scale` in its calculations.
- Increased allowed strength parameter range for `grow_sphere` from [0, 1] to [0, 10].