### PR TITLE
Fix crash when saving an empty VoxelBlockyType

### DIFF
--- a/meshers/blocky/types/voxel_blocky_type_library.cpp
+++ b/meshers/blocky/types/voxel_blocky_type_library.cpp
@@ -112,6 +112,10 @@ void VoxelBlockyTypeLibrary::update_id_map(StdVector<VoxelID> &id_map, StdVector
 	for (size_t i = 0; i < _types.size(); ++i) {
 		Ref<VoxelBlockyType> type = _types[i];
 
+		if (type == nullptr) {
+			continue;
+		}
+
 		type->generate_keys(keys, true);
 
 		VoxelID id;


### PR DESCRIPTION
The editor will crash if you try to save a scene with an empty VoxelBlockyType.

This PR fixes that by adding a null check.