### PR TITLE
fix: editor_plugin.h was moved to editor/plugins

### DIFF
--- a/editor/fast_noise_2/fast_noise_2_editor_plugin.h
+++ b/editor/fast_noise_2/fast_noise_2_editor_plugin.h
@@ -1,7 +1,7 @@
 #ifndef FAST_NOISE_2_EDITOR_PLUGIN_H
 #define FAST_NOISE_2_EDITOR_PLUGIN_H
 
-#include <editor/editor_plugin.h>
+#include <editor/plugins/editor_plugin.h>
 
 namespace zylann {
 

--- a/util/godot/classes/editor_plugin.h
+++ b/util/godot/classes/editor_plugin.h
@@ -2,7 +2,7 @@
 #define ZN_GODOT_EDITOR_PLUGIN_H
 
 #if defined(ZN_GODOT)
-#include <editor/editor_plugin.h>
+#include <editor/plugins/editor_plugin.h>
 
 #elif defined(ZN_GODOT_EXTENSION)
 // Header includes required due to implementation being required inside the `GDCLASS` macro for virtual methods...


### PR DESCRIPTION
Looks like `editor/editor_plugin.h` was moved to `editor/plugins/` so the build fails with the latest master branch (see here: https://github.com/godotengine/godot/pull/90975).

