### PR TITLE
Fix fuzzer

### DIFF
--- a/.github/workflows/fuzzer.yml
+++ b/.github/workflows/fuzzer.yml
@@ -117,6 +117,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: qarmin/Qarminer
+          # At the time of writing, qarmin did not put out later than 4.1 versions, but claims that it works with Godot versions up to 4.3+
+          # See https://github.com/qarmin/Qarminer/issues/32
           ref: 4.1
           path: fuzzer
 

--- a/.github/workflows/fuzzer.yml
+++ b/.github/workflows/fuzzer.yml
@@ -59,11 +59,13 @@ jobs:
             ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
             ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
 
+      # Fix the issue of running out of disk space during Compilation stage
+      # Taken from here: https://github.com/orgs/community/discussions/26351#discussioncomment-3251595
       - name: Free disk space
         run: |
           sudo swapoff -a
           sudo rm -f /swapfile
-          sudo apt clean
+          sudo apt-get clean
           docker rmi $(docker image ls -aq)
           df -h
 
@@ -115,7 +117,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: qarmin/Qarminer
-          ref: ${{ env.GODOT_BASE_BRANCH }}
+          ref: 4.1
           path: fuzzer
 
       - name: Copy fuzzer settings

--- a/.github/workflows/fuzzer.yml
+++ b/.github/workflows/fuzzer.yml
@@ -59,6 +59,14 @@ jobs:
             ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
             ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
 
+      - name: Free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
+
       # NO-PIE is for more detailed bactraces with line symbols
       - name: Compilation
         env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Voxel Tools for Godot
 =========================
 
+
+
 A C++ module for creating volumetric worlds in Godot Engine 4.
 
 [![🚪 Windows Builds](https://github.com/Zylann/godot_voxel/actions/workflows/windows.yml/badge.svg)](https://github.com/Zylann/godot_voxel/actions/workflows/windows.yml)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 Voxel Tools for Godot
 =========================
 
-
-
 A C++ module for creating volumetric worlds in Godot Engine 4.
 
 [![🚪 Windows Builds](https://github.com/Zylann/godot_voxel/actions/workflows/windows.yml/badge.svg)](https://github.com/Zylann/godot_voxel/actions/workflows/windows.yml)


### PR DESCRIPTION
Fixed fuzzer issues:
- `System.IO.IOException: No space left on device`: fixed by adding `Free disk space` step before compilation step.
- Then there was an issue of step trying to fetch 4.2 version of `qarmin/Qarminer` repository, but only 4.1 exists there. I made an [issue](https://github.com/qarmin/Qarminer/issues/32) about it, but the author said that 4.1 version should work with Godot version up to 4.3+. So I hardcoded it to 4.1 for now. This may need to be updated later.

Fuzzer working and catching Godot crashes can be seen here:
<https://github.com/Piratux/godot_voxel/actions/runs/9821448650>