### PR TITLE
modifiers: support nesting

### DIFF
--- a/modifiers/godot/voxel_modifier_gd.cpp
+++ b/modifiers/godot/voxel_modifier_gd.cpp
@@ -121,23 +121,25 @@ void VoxelModifier::_notification(int p_what) {
 		} break;
 
 		case Node3D::NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
-			if (_volume != nullptr && is_inside_tree()) {
-				VoxelData &voxel_data = _volume->get_storage();
-				VoxelModifierStack &modifiers = voxel_data.get_modifiers();
-				zylann::voxel::VoxelModifier *modifier = modifiers.get_modifier(_modifier_id);
-				ZN_ASSERT_RETURN(modifier != nullptr);
-
-				const AABB prev_aabb = modifier->get_aabb();
-				modifier->set_transform(get_transform());
-				const AABB aabb = modifier->get_aabb();
-				post_edit_modifier(*_volume, prev_aabb);
-				post_edit_modifier(*_volume, aabb);
-
-				// TODO Handle nesting properly, though it's a pain in the ass
-				// When the terrain is moved, the local transform of modifiers technically changes too.
-				// However it did not change relative to the terrain. But because we don't have a way to check that,
-				// all modifiers will trigger updates at the same time...
+			if (_volume == nullptr || !is_inside_tree()) {
+				return;
 			}
+			
+			VoxelData &voxel_data = _volume->get_storage();
+			VoxelModifierStack &modifiers = voxel_data.get_modifiers();
+			zylann::voxel::VoxelModifier *modifier = modifiers.get_modifier(_modifier_id);
+			ZN_ASSERT_RETURN(modifier != nullptr);
+
+			const AABB prev_aabb = modifier->get_aabb();
+			modifier->set_transform(get_transform());
+			const AABB aabb = modifier->get_aabb();
+			post_edit_modifier(*_volume, prev_aabb);
+			post_edit_modifier(*_volume, aabb);
+
+			// TODO Handle nesting properly, though it's a pain in the ass
+			// When the terrain is moved, the local transform of modifiers technically changes too.
+			// However it did not change relative to the terrain. But because we don't have a way to check that,
+			// all modifiers will trigger updates at the same time...
 		} break;
 	}
 }

--- a/modifiers/godot/voxel_modifier_gd.h
+++ b/modifiers/godot/voxel_modifier_gd.h
@@ -47,9 +47,17 @@ protected:
 
 private:
 	static void _bind_methods();
+	Transform3D get_terrain_local_transform() const;
+	VoxelLodTerrain *get_ancestor_volume() const;
 
 	Operation _operation = OPERATION_ADD;
 	float _smoothness = 0.f;
+
+	// Tracks the last-known transform of the modifier, in terrain-local space.
+	// This alows us to distinguish between transform updates caused by the entire terrain moving
+	// from updates caused by the modifier moving relative to the terrain. Only the latter requires
+	// a remesh.
+	Transform3D _last_tl_transform;
 };
 
 // Helpers

--- a/terrain/variable_lod/voxel_lod_terrain.cpp
+++ b/terrain/variable_lod/voxel_lod_terrain.cpp
@@ -3442,10 +3442,10 @@ void VoxelLodTerrain::update_gizmos() {
 	// Modifiers
 	if (debug_get_draw_flag(DEBUG_DRAW_MODIFIER_BOUNDS)) {
 		const VoxelModifierStack &modifiers = _data->get_modifiers();
-		modifiers.for_each_modifier([&dr](const VoxelModifier &modifier) {
+		modifiers.for_each_modifier([&dr, parent_transform](const VoxelModifier &modifier) {
 			const AABB aabb = modifier.get_aabb();
 			const Transform3D t(Basis().scaled(aabb.size), aabb.get_center() - aabb.size * 0.5);
-			dr.draw_box(t, Color8(0, 0, 255, 255));
+			dr.draw_box(parent_transform * t, Color8(0, 0, 255, 255));
 		});
 	}
 


### PR DESCRIPTION
This PR improves/adds support for nested modifier structures in the voxel lod terrain tree.

These changes are not of particular importance to me (other than the ability to filter out terrain translation). I just happened to be in the area and noticed your TODO comment, and I thought this might be a good place to cut my teeth.