### PR TITLE
Fix save_generator_output not working in VoxelLodTerrain.

### DIFF
--- a/terrain/variable_lod/voxel_lod_terrain_update_data.h
+++ b/terrain/variable_lod/voxel_lod_terrain_update_data.h
@@ -72,7 +72,7 @@ struct VoxelLodTerrainUpdateData {
 		// If true, try to generate blocks and store them in the data map before posting mesh requests.
 		// If false, meshing will generate non-edited voxels on the fly instead.
 		// Not really exposed for now, will wait for it to be really needed. It might never be.
-		bool cache_generated_blocks = false;
+		bool cache_generated_blocks = true;
 		bool collision_enabled = true;
 		bool detail_textures_use_gpu = false;
 		bool generator_use_gpu = false;


### PR DESCRIPTION
cache_generated_blocks is passed to LoadBlockDataTask where it is used to check if a block should be generated and saved if not found by the stream. However, it default constructs to false and is never written to. Meaning this check will always fail.

https://github.com/Zylann/godot_voxel/blob/f79a29f418554049d91a85e7dfdd8d415dea557e/streams/load_block_data_task.cpp#L67-L97

Setting this to construct as true fixes the issue and better aligns with how VoxelTerrain is written. But if there is a better option for fixing this I'm happy to change it.