### PR TITLE
Fix GDExtension build error: incomplete type 'godot::Variant'

### DIFF
--- a/util/godot/core/dictionary.h
+++ b/util/godot/core/dictionary.h
@@ -5,6 +5,7 @@
 #include <core/variant/dictionary.h>
 #elif defined(ZN_GODOT_EXTENSION)
 #include <godot_cpp/variant/dictionary.hpp>
+#include <godot_cpp/variant/variant.hpp>
 using namespace godot;
 #endif
 


### PR DESCRIPTION
I was getting this error while compiling GDExtension
```
In file included from generators/graph/voxel_generator_graph.h:7,
                 from generators/graph/voxel_generator_graph.cpp:1:
generators/graph/../../util/godot/core/dictionary.h: In function 'bool zylann::godot::try_get(const godot::Dictionary&, const godot::Variant&, T&)':
generators/graph/../../util/godot/core/dictionary.h:26:17: error: 'v' has incomplete type
   26 |         Variant v = d.get(key, Variant());
      |                 ^
In file included from generators/graph/../../util/godot/core/dictionary.h:7:
godot-cpp/gen/include/godot_cpp/variant/dictionary.hpp:43:7: note: forward declaration of 'class godot::Variant'
   43 | class Variant;
      |       ^~~~~~~
generators/graph/../../util/godot/core/dictionary.h:29:38: error: incomplete type 'godot::Variant' used in nested name specifier
   29 |         if (v.get_type() == Variant::NIL) {
      |                                      ^~~
```
Suggesting that Variant type is only forward declared in dictionary.hpp, but does not include its full definition.