### PR TITLE
Fix for GPU Generation Hitting Rid Allocation Limit

### DIFF
--- a/generators/generate_block_gpu_task.cpp
+++ b/generators/generate_block_gpu_task.cpp
@@ -151,7 +151,7 @@ void GenerateBlockGPUTask::prepare(GPUTaskContext &ctx) {
 		// Note, this internally locks RenderingDeviceVulkan's class mutex. Which means it could perhaps be used outside
 		// of the compute list (which already locks the class mutex until it ends). Thankfully, it uses a recursive
 		// Mutex (instead of BinaryMutex)
-		const RID generator_uniform_set =
+		_generator_uniform_set =
 				zylann::godot::uniform_set_create(rd, generator_uniforms, generator_shader_rid, 0);
 
 		{
@@ -160,7 +160,7 @@ void GenerateBlockGPUTask::prepare(GPUTaskContext &ctx) {
 		}
 		{
 			ZN_PROFILE_SCOPE_NAMED("compute_list_bind_uniform_set");
-			rd.compute_list_bind_uniform_set(compute_list_id, generator_uniform_set, 0);
+			rd.compute_list_bind_uniform_set(compute_list_id, _generator_uniform_set, 0);
 		}
 
 		const Box3i &box = boxes_to_generate[box_index];
@@ -464,7 +464,8 @@ void GenerateBlockGPUTask::collect(GPUTaskContext &ctx) {
 	}
 
 	zylann::godot::free_rendering_device_rid(rd, _generator_pipeline_rid);
-
+	zylann::godot::free_rendering_device_rid(rd, _generator_uniform_set);
+	
 	for (RID rid : _modifier_pipelines) {
 		zylann::godot::free_rendering_device_rid(rd, rid);
 	}

--- a/generators/generate_block_gpu_task.h
+++ b/generators/generate_block_gpu_task.h
@@ -83,7 +83,7 @@ private:
 
 	StdVector<BoxData> _boxes_data;
 	RID _generator_pipeline_rid;
-	RID _generator_uniform_set;
+	StdVector<RID> _generator_uniform_sets;
 	StdVector<RID> _modifier_pipelines;
 };
 

--- a/generators/generate_block_gpu_task.h
+++ b/generators/generate_block_gpu_task.h
@@ -83,6 +83,7 @@ private:
 
 	StdVector<BoxData> _boxes_data;
 	RID _generator_pipeline_rid;
+	RID _generator_uniform_set;
 	StdVector<RID> _modifier_pipelines;
 };
 


### PR DESCRIPTION
I was running into an issue where after a couple of minutes of flying around with gpu generation on where I would start hitting the rid allocation limit. I took a look at the code and noticed the generator_uniform_set variable was being created but never cleared as far as I could tell. So I switched it to a member variable like _generator_pipeline_rid and freed it along with that and it seems to fix the problem. 

I didn't see any resource allocation issues after ~15 minutes of flying around with this change where as before I was hitting the issue after ~3 minutes. 