### PR TITLE
Allow to set thread count at runtime

### DIFF
--- a/doc/classes/VoxelEngine.xml
+++ b/doc/classes/VoxelEngine.xml
@@ -42,6 +42,19 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="get_thread_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of threads currently used internally by the [code]ThreadedTaskRunner[/code].
+			</description>
+		</method>
+		<method name="set_thread_count">
+			<return type="void" />
+			<param index="0" name="count" type="int" />
+			<description>
+				Sets the number of threads to be used internally by the [code]ThreadedTaskRunner[/code]. Setting this can cause lagging, and it might take some time until the number of threads actually matches the given value.
+			</description>
+		</method>
 		<method name="get_threaded_graphics_resource_building_enabled" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/engine/voxel_engine.cpp
+++ b/engine/voxel_engine.cpp
@@ -411,7 +411,7 @@ int VoxelEngine::get_thread_count() const {
 	return _general_thread_pool.get_thread_count();
 }
 
-void VoxelEngine::set_thread_count(int count) {
+void VoxelEngine::set_thread_count(uint32_t count) {
 	_general_thread_pool.set_thread_count(count);
 }
 

--- a/engine/voxel_engine.cpp
+++ b/engine/voxel_engine.cpp
@@ -407,4 +407,12 @@ VoxelEngine::Stats VoxelEngine::get_stats() const {
 	return s;
 }
 
+int VoxelEngine::get_thread_count() const {
+	return _general_thread_pool.get_thread_count();
+}
+
+void VoxelEngine::set_thread_count(int count) {
+	_general_thread_pool.set_thread_count(count);
+}
+
 } // namespace zylann::voxel

--- a/engine/voxel_engine.h
+++ b/engine/voxel_engine.h
@@ -275,7 +275,7 @@ public:
 	Stats get_stats() const;
 
 	int get_thread_count() const;
-	void set_thread_count(int count);
+	void set_thread_count(uint32_t count);
 
 #ifdef VOXEL_ENABLE_GPU
 	bool has_rendering_device() const {

--- a/engine/voxel_engine.h
+++ b/engine/voxel_engine.h
@@ -274,6 +274,9 @@ public:
 
 	Stats get_stats() const;
 
+	int get_thread_count() const;
+	void set_thread_count(int count);
+
 #ifdef VOXEL_ENABLE_GPU
 	bool has_rendering_device() const {
 		return _gpu_task_runner.has_rendering_device();

--- a/engine/voxel_engine_gd.cpp
+++ b/engine/voxel_engine_gd.cpp
@@ -177,6 +177,19 @@ Dictionary VoxelEngine::get_stats() const {
 	return to_dict(zylann::voxel::VoxelEngine::get_singleton().get_stats());
 }
 
+int VoxelEngine::get_thread_count() const {
+	return zylann::voxel::VoxelEngine::get_singleton().get_thread_count();
+}
+
+void VoxelEngine::set_thread_count(int count) {
+	ERR_FAIL_COND_MSG(count < 1,
+			vformat("The thread count must be a number from 1 to %d", ThreadedTaskRunner::MAX_THREADS));
+	// if `thread_count` is bigger than MAX_THREADS we allow the function to continue,
+	// as the rest of the code is build to handle this
+
+	zylann::voxel::VoxelEngine::get_singleton().set_thread_count(count);
+}
+
 void VoxelEngine::schedule_task(Ref<ZN_ThreadedTask> task) {
 	ERR_FAIL_COND(task.is_null());
 	ERR_FAIL_COND_MSG(task->is_scheduled(), "Cannot schedule again a task that is already scheduled");
@@ -235,6 +248,8 @@ void VoxelEngine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_version_status"), &VoxelEngine::get_version_status);
 	ClassDB::bind_method(D_METHOD("get_version_git_hash"), &VoxelEngine::get_version_git_hash);
 	ClassDB::bind_method(D_METHOD("get_stats"), &VoxelEngine::get_stats);
+	ClassDB::bind_method(D_METHOD("get_thread_count"), &VoxelEngine::get_thread_count);
+	ClassDB::bind_method(D_METHOD("set_thread_count", "count"), &VoxelEngine::set_thread_count);
 
 	ClassDB::bind_method(
 			D_METHOD("get_threaded_graphics_resource_building_enabled"),

--- a/engine/voxel_engine_gd.cpp
+++ b/engine/voxel_engine_gd.cpp
@@ -181,10 +181,11 @@ int VoxelEngine::get_thread_count() const {
 	return zylann::voxel::VoxelEngine::get_singleton().get_thread_count();
 }
 
-void VoxelEngine::set_thread_count(uint32_t count) {
-	ERR_FAIL_COND_MSG(count < 1 || count > ThreadedTaskRunner::MAX_THREADS,
-			vformat("Thread count must be a number from 1 to %d", ThreadedTaskRunner::MAX_THREADS));
-	zylann::voxel::VoxelEngine::get_singleton().set_thread_count(count);
+void VoxelEngine::set_thread_count(int count) {
+	constexpr int MAX_THREADS = static_cast<int>(ThreadedTaskRunner::MAX_THREADS);
+	ERR_FAIL_COND_MSG(count < 1 || count > MAX_THREADS,
+			vformat("Thread count must be a number from 1 to %d", MAX_THREADS));
+	zylann::voxel::VoxelEngine::get_singleton().set_thread_count(static_cast<uint32_t>(count));
 }
 
 void VoxelEngine::schedule_task(Ref<ZN_ThreadedTask> task) {

--- a/engine/voxel_engine_gd.cpp
+++ b/engine/voxel_engine_gd.cpp
@@ -181,12 +181,9 @@ int VoxelEngine::get_thread_count() const {
 	return zylann::voxel::VoxelEngine::get_singleton().get_thread_count();
 }
 
-void VoxelEngine::set_thread_count(int count) {
-	ERR_FAIL_COND_MSG(count < 1,
-			vformat("The thread count must be a number from 1 to %d", ThreadedTaskRunner::MAX_THREADS));
-	// if `thread_count` is bigger than MAX_THREADS we allow the function to continue,
-	// as the rest of the code is build to handle this
-
+void VoxelEngine::set_thread_count(uint32_t count) {
+	ERR_FAIL_COND_MSG(count < 1 || count > ThreadedTaskRunner::MAX_THREADS,
+			vformat("Thread count must be a number from 1 to %d", ThreadedTaskRunner::MAX_THREADS));
 	zylann::voxel::VoxelEngine::get_singleton().set_thread_count(count);
 }
 

--- a/engine/voxel_engine_gd.h
+++ b/engine/voxel_engine_gd.h
@@ -39,7 +39,7 @@ public:
 	void schedule_task(Ref<ZN_ThreadedTask> task);
 
 	int get_thread_count() const;
-	void set_thread_count(int count);
+	void set_thread_count(uint32_t count);
 
 #ifdef TOOLS_ENABLED
 	void set_editor_camera_info(Vector3 position, Vector3 direction);

--- a/engine/voxel_engine_gd.h
+++ b/engine/voxel_engine_gd.h
@@ -39,7 +39,7 @@ public:
 	void schedule_task(Ref<ZN_ThreadedTask> task);
 
 	int get_thread_count() const;
-	void set_thread_count(uint32_t count);
+	void set_thread_count(int count);
 
 #ifdef TOOLS_ENABLED
 	void set_editor_camera_info(Vector3 position, Vector3 direction);

--- a/engine/voxel_engine_gd.h
+++ b/engine/voxel_engine_gd.h
@@ -38,6 +38,9 @@ public:
 	Dictionary get_stats() const;
 	void schedule_task(Ref<ZN_ThreadedTask> task);
 
+	int get_thread_count() const;
+	void set_thread_count(int count);
+
 #ifdef TOOLS_ENABLED
 	void set_editor_camera_info(Vector3 position, Vector3 direction);
 	Vector3 get_editor_camera_position() const;

--- a/util/tasks/threaded_task_runner.cpp
+++ b/util/tasks/threaded_task_runner.cpp
@@ -90,11 +90,11 @@ void ThreadedTaskRunner::set_thread_count(uint32_t count) {
 		count = MAX_THREADS;
 	}
 	destroy_all_threads();
-	for (uint32_t i = _thread_count; i < count; ++i) {
+	_thread_count = count;
+	for (uint32_t i = 0; i < _thread_count; ++i) {
 		ThreadData &d = _threads[i];
 		create_thread(d, i);
 	}
-	_thread_count = count;
 }
 
 void ThreadedTaskRunner::set_priority_update_period(uint32_t milliseconds) {

--- a/util/tasks/threaded_task_runner.h
+++ b/util/tasks/threaded_task_runner.h
@@ -27,7 +27,7 @@ namespace zylann {
 // Generic thread pool that performs batches of tasks based on dynamic priority
 class ThreadedTaskRunner {
 public:
-	static const uint32_t MAX_THREADS = 16;
+	static constexpr uint32_t MAX_THREADS = 128;
 
 	enum State { //
 		STATE_RUNNING = 0,


### PR DESCRIPTION
This PR exposes two new methods in the `VoxelEngine` singleton (the GDScript version of the class):

- `int get_thread_count()`:
Returns the number of currently used threads in the thread pool.
Implemented as a call chain:
```
zylann::voxel::godot::VoxelEngine.get_thread_count()
  -> zylann::voxel::VoxelEngine.get_thread_count()
    -> _general_thread_pool.get_thread_count()
```

- `void set_thread_count(int count)`:
Sets the number of threads to be used by the thread pool.
Also implemented as a call chain:
```
zylann::voxel::godot::VoxelEngine.set_thread_count(int count)
  -> zylann::voxel::VoxelEngine.set_thread_count(int count)
    -> _general_thread_pool.set_thread_count(int count)
```

The docs have been updated to include these two new methods.

This PR also includes a fix for how the `ThreadedTaskRunner` handles a change of thread count.

I have tested this both with the official [voxelgame](https://github.com/Zylann/voxelgame) demo and my personal project.
It doesn't seem any tasks get dropped, so the internal logic of `destroy_all_threads()` with subsequent calls to `create_thread(d, i)` appears to be robust. However, yielding all threads can cause noticeable stuttering, as is described in the docs.
Depending on the use case, this might be negligible though.

Motivation:
The new methods added by this PR perfectly complement a terrain pre-generation approach using a roamer: The thread count can be set to a very high value on first generation, then the roamer can be run, and finally the thread count can be lowered again to allow fluid gameplay.