### PR TITLE
`run_blocky_random_tick`: Add zero block count check

### DIFF
--- a/edition/funcs.cpp
+++ b/edition/funcs.cpp
@@ -149,7 +149,7 @@ void run_blocky_random_tick(
 		bool (*callback)(void *, Vector3i, int64_t)
 ) {
 	ERR_FAIL_COND(batch_count <= 0);
-	ERR_FAIL_COND(voxel_count < 0);
+	ERR_FAIL_COND(voxel_count <= 0);
 	ERR_FAIL_COND(!math::is_valid_size(voxel_box.size));
 	ERR_FAIL_COND(callback == nullptr);
 
@@ -159,6 +159,8 @@ void run_blocky_random_tick(
 	const Box3i block_box = voxel_box.downscaled(block_size);
 
 	const int block_count = voxel_count / batch_count;
+	ERR_FAIL_COND(block_count < 1);
+
 	// const int bs_mask = map.get_block_size_mask();
 	const VoxelBuffer::ChannelId channel = VoxelBuffer::CHANNEL_TYPE;
 


### PR DESCRIPTION
Just played around with the batch count, and noticed that the `voxel_count` must always be larger than or equal to the `batch_count`, otherwise the function will do nothing. I was quite confused about what's going on.
Of course it's obvious once you know what the two parameters actually do and that you cast to int for the `block_count`. Anyways, having the function call silently do nothing if "bad" values are supplied didn't sound like a good idea IMHO, so I added an error message if `block_count < 1`.

Not sure if it's better to just print an error so that the users knows what's going on, or if it would be better to just silently clamp the `block_count` at 1 so that the function still works even if bad input values are given.

I know the current behavior is somewhat deliberate (`voxel_count < 0` check), so let me know what you think.