### PR TITLE
Fix Android compilation error

### DIFF
--- a/terrain/fixed_lod/voxel_mesh_block_vt.h
+++ b/terrain/fixed_lod/voxel_mesh_block_vt.h
@@ -80,7 +80,7 @@ public:
 #ifdef TOOLS_ENABLED
 				shadow_occluder.set_cast_shadows_setting(shadow_occluder_mode);
 #else
-				shadow_occluder.set_cast_shadows_setting(RenderingServer::SHADOW_CASTING_SETTING_SHADOWS_ONLY);
+				shadow_occluder.set_cast_shadows_setting(RenderingServerEnums::SHADOW_CASTING_SETTING_SHADOWS_ONLY);
 #endif
 				set_mesh_instance_visible(shadow_occluder, _visible && _parent_visible);
 			}

--- a/terrain/variable_lod/voxel_mesh_block_vlt.cpp
+++ b/terrain/variable_lod/voxel_mesh_block_vlt.cpp
@@ -79,7 +79,7 @@ void VoxelMeshBlockVLT::set_mesh(
 #ifdef TOOLS_ENABLED
 			_shadow_occluder.set_cast_shadows_setting(shadow_occluder_mode);
 #else
-			_shadow_occluder.set_cast_shadows_setting(RenderingServer::SHADOW_CASTING_SETTING_SHADOWS_ONLY);
+			_shadow_occluder.set_cast_shadows_setting(RenderingServerEnums::SHADOW_CASTING_SETTING_SHADOWS_ONLY);
 #endif
 			// TODO Should we hide it if shadow casting is off?
 			// TBH it would be even better for the user to simply turn these off in the mesher...


### PR DESCRIPTION
`SHADOW_CASTING_SETTING_SHADOWS_ONLY` is now moved to `RenderingServerEnums` namespace, which makes it unable to compile for android devices. This PR fixed the problem.