### PR TITLE
Compute shader cache

### DIFF
--- a/engine/gpu/compute_shader.cpp
+++ b/engine/gpu/compute_shader.cpp
@@ -62,24 +62,27 @@ PackedByteArray load_compute_shader_binary_from_cache(const String &cache_file_p
 
 	Error open_error;
 	Ref<FileAccess> file = zylann::godot::open_file(cache_file_path, FileAccess::READ, open_error);
-	if (file.is_null()) {
-		ZN_PRINT_VERBOSE(format("Could not open VoxelRD compute shader binary cache file {} (error {})", cache_file_path, open_error));
-		return PackedByteArray();
-	}
+	ZN_ASSERT_RETURN_V_MSG(
+			file.is_valid(),
+			PackedByteArray(),
+			format("Could not open VoxelRD compute shader binary cache file {} (error {})", cache_file_path, open_error)
+	);
 
 	const uint64_t length = file->get_length();
-	if (length == 0) {
-		ZN_PRINT_VERBOSE(format("VoxelRD compute shader binary cache file is empty for {}", cache_file_path));
-		return PackedByteArray();
-	}
+	ZN_ASSERT_RETURN_V_MSG(
+			length != 0,
+			PackedByteArray(),
+			format("VoxelRD compute shader binary cache file is empty for {}", cache_file_path)
+	);
 
 	PackedByteArray bytes;
 	bytes.resize(length);
 	const uint64_t read_count = zylann::godot::get_buffer(**file, Span<uint8_t>(bytes.ptrw(), bytes.size()));
-	if (read_count != length) {
-		ZN_PRINT_VERBOSE(format("Could not read full VoxelRD compute shader binary cache file for {}", cache_file_path));
-		return PackedByteArray();
-	}
+	ZN_ASSERT_RETURN_V_MSG(
+			read_count == length,
+			PackedByteArray(),
+			format("Could not read full VoxelRD compute shader binary cache file for {}", cache_file_path)
+	);
 
 	return bytes;
 }

--- a/engine/gpu/compute_shader.cpp
+++ b/engine/gpu/compute_shader.cpp
@@ -43,23 +43,19 @@ String get_voxel_compute_shader_cache_base_dir() {
 	base_dir = Engine::get_singleton()->get_shader_cache_path();
 #endif
 	if (base_dir.is_empty()) {
-		base_dir = "user://shader_cache";
+		base_dir = "user://";
 	}
-	return base_dir;
-}
-
-String get_compute_shader_cache_dir(const String &name) {
-	return get_voxel_compute_shader_cache_base_dir()
-			.path_join(name.validate_filename());
+	return base_dir.path_join("shader_cache");
 }
 
 String get_compute_shader_binary_cache_path(const String &source_hash, const String &device_cache_uuid, const String &name) {
 	
-	return get_compute_shader_cache_dir(name)
+	return get_voxel_compute_shader_cache_base_dir()
+			.path_join(name.validate_filename())
 			.path_join(vformat("%s.%s.bin.cache", source_hash, device_cache_uuid));
 }
 
-PackedByteArray load_compute_shader_binary_from_cache(const String &cache_file_path, const String &shader_name) {
+PackedByteArray load_compute_shader_binary_from_cache(const String &cache_file_path) {
 	if (!zylann::godot::file_exists(cache_file_path)) {
 		return PackedByteArray();
 	}
@@ -67,13 +63,13 @@ PackedByteArray load_compute_shader_binary_from_cache(const String &cache_file_p
 	Error open_error;
 	Ref<FileAccess> file = zylann::godot::open_file(cache_file_path, FileAccess::READ, open_error);
 	if (file.is_null()) {
-		ZN_PRINT_VERBOSE(format("Could not open VoxelRD compute shader binary cache file {} for {}", cache_file_path, shader_name));
+		ZN_PRINT_VERBOSE(format("Could not open VoxelRD compute shader binary cache file {} (error {})", cache_file_path, open_error));
 		return PackedByteArray();
 	}
 
 	const uint64_t length = file->get_length();
 	if (length == 0) {
-		ZN_PRINT_VERBOSE(format("VoxelRD compute shader binary cache file is empty for {}", shader_name));
+		ZN_PRINT_VERBOSE(format("VoxelRD compute shader binary cache file is empty for {}", cache_file_path));
 		return PackedByteArray();
 	}
 
@@ -81,7 +77,7 @@ PackedByteArray load_compute_shader_binary_from_cache(const String &cache_file_p
 	bytes.resize(length);
 	const uint64_t read_count = zylann::godot::get_buffer(**file, Span<uint8_t>(bytes.ptrw(), bytes.size()));
 	if (read_count != length) {
-		ZN_PRINT_VERBOSE(format("Could not read full VoxelRD compute shader binary cache file for {}", shader_name));
+		ZN_PRINT_VERBOSE(format("Could not read full VoxelRD compute shader binary cache file for {}", cache_file_path));
 		return PackedByteArray();
 	}
 
@@ -106,7 +102,7 @@ void save_compute_shader_binary_to_cache(
 	Error open_error;
 	Ref<FileAccess> file = zylann::godot::open_file(cache_file_path, FileAccess::WRITE, open_error);
 	if (file.is_null()) {
-		ZN_PRINT_WARNING(format("Could not open VoxelRD compute shader binary cache file {} for writing", cache_file_path));
+		ZN_PRINT_WARNING(format("Could not open VoxelRD compute shader binary cache file {} for writing (error {})", cache_file_path, open_error));
 		return;
 	}
 
@@ -116,8 +112,6 @@ void save_compute_shader_binary_to_cache(
 } // namespace
 
 Ref<RDShaderSPIRV> compile_compute_shader_spirv_from_glsl(RenderingDevice &rd, String source_text, String name) {
-	// Refactored since both cache and non cache paths need this
-	
 	Ref<RDShaderSource> shader_source;
 	shader_source.instantiate();
 	shader_source->set_language(RenderingDevice::SHADER_LANGUAGE_GLSL);
@@ -142,7 +136,7 @@ Ref<RDShaderSPIRV> compile_compute_shader_spirv_from_glsl(RenderingDevice &rd, S
 	return shader_spirv;
 }
 
-RID load_compute_shader_from_glsl(RenderingDevice &rd, String source_text, String name) {
+RID load_compute_shader_from_glsl(RenderingDevice &rd, String source_text, String name, bool shader_cache_enabled) {
 	ZN_PRINT_VERBOSE(format("Creating VoxelRD compute shader {}", name));
 	// For debugging
 	// {
@@ -159,49 +153,44 @@ RID load_compute_shader_from_glsl(RenderingDevice &rd, String source_text, Strin
 	// );
 	// MutexLock mlock(VoxelEngine::get_singleton().get_rendering_device_mutex());
 
-	Ref<RDShaderSPIRV> shader_spirv = compile_compute_shader_spirv_from_glsl(rd, source_text, name);
-	ERR_FAIL_COND_V(shader_spirv.is_null(), RID());
-
-	RID shader_rid = zylann::godot::shader_create_from_spirv(rd, **shader_spirv, name);
-	ERR_FAIL_COND_V(!shader_rid.is_valid(), RID());
-
-	return shader_rid;
-}
-
-RID load_compute_shader_from_glsl_cached(RenderingDevice &rd, String source_text, String name) {
 	ZN_PRINT_VERBOSE(format("Creating VoxelRD compute shader {}", name));
 
 	const String source_hash = source_text.sha256_text();
 	const String binary_cache_file_path =
 			get_compute_shader_binary_cache_path(source_hash, rd.get_device_pipeline_cache_uuid(), name);
+	
+	PackedByteArray shader_binary;
+	RID shader_rid;
 
-	PackedByteArray shader_binary = load_compute_shader_binary_from_cache(binary_cache_file_path, name);
+	// Load the shader cache if enabled
+	if(shader_cache_enabled){
+		shader_binary = load_compute_shader_binary_from_cache(binary_cache_file_path);
+	}
+
 	if (!shader_binary.is_empty()) {
-		RID shader_rid = rd.shader_create_from_bytecode(shader_binary);
+		shader_rid = rd.shader_create_from_bytecode(shader_binary);
 		if (shader_rid.is_valid()) {
 			ZN_PRINT_VERBOSE(format("Loaded VoxelRD compute shader {} from binary cache", name));
 			return shader_rid;
 		}
-		ZN_PRINT_VERBOSE(format("VoxelRD compute shader binary cache rejected by RenderingDevice for {}", name));
-	}
 
+		ZN_PRINT_VERBOSE(format("VoxelRD compute shader binary cache rejected by RenderingDevice for {}", name));
+	}  
+
+	// Either no cache existed or the cache was rejected, remake it
 	Ref<RDShaderSPIRV> shader_spirv = compile_compute_shader_spirv_from_glsl(rd, source_text, name);
 	ERR_FAIL_COND_V(shader_spirv.is_null(), RID());
 
 	shader_binary = zylann::godot::shader_compile_binary_from_spirv(rd, **shader_spirv, name);
 	ERR_FAIL_COND_V(shader_binary.is_empty(), RID());
 
-	save_compute_shader_binary_to_cache(binary_cache_file_path, shader_binary, name);
+	// Only cache if enabled
+	if(shader_cache_enabled)
+	{
+		save_compute_shader_binary_to_cache(binary_cache_file_path, shader_binary, name);
+	}		
 
-	RID shader_rid = rd.shader_create_from_bytecode(shader_binary);
-	if (shader_rid.is_valid()) {
-		return shader_rid;
-	}
-
-	ZN_PRINT_VERBOSE(format("VoxelRD compute shader binary rejected by RenderingDevice for {}, falling back to SPIR-V", name));
-
-	shader_rid = zylann::godot::shader_create_from_spirv(rd, **shader_spirv, name);
-	ERR_FAIL_COND_V(!shader_rid.is_valid(), RID());
+	shader_rid = rd.shader_create_from_bytecode(shader_binary);
 
 	return shader_rid;
 }
@@ -227,11 +216,8 @@ void ComputeShaderInternal::load_from_glsl(RenderingDevice &rd, String source_te
 
 	ZN_ASSERT(ProjectSettings::get_singleton() != nullptr);
 	const bool shader_cache_enabled = ProjectSettings::get_singleton()->get("voxel/shaders/shader_cache/enabled");
-	if (shader_cache_enabled) {
-		rid = load_compute_shader_from_glsl_cached(rd, source_text, name);
-	} else {
-		rid = load_compute_shader_from_glsl(rd, source_text, name);
-	}
+	rid = load_compute_shader_from_glsl(rd, source_text, name, shader_cache_enabled);
+
 #if DEBUG_ENABLED
 	debug_name = name;
 #endif

--- a/engine/gpu/compute_shader.cpp
+++ b/engine/gpu/compute_shader.cpp
@@ -1,8 +1,14 @@
 #include "compute_shader.h"
+#include "../../util/godot/classes/directory.h"
+#include "../../util/godot/classes/engine.h"
+#include "../../util/godot/classes/file_access.h"
 #include "../../util/godot/classes/rd_shader_source.h"
 #include "../../util/godot/classes/rendering_server.h"
 #include "../../util/godot/core/array.h" // for `varray` in GDExtension builds
+#include "../../util/godot/core/packed_arrays.h"
 #include "../../util/godot/core/print_string.h"
+#include "../../util/godot/classes/project_settings.h"
+#include "../../util/io/log.h"
 #include "../../util/profiling.h"
 #include "../../util/string/format.h"
 #include "../voxel_engine.h"
@@ -29,32 +35,98 @@ String format_source_code_with_line_numbers(String src) {
 	return dst;
 }
 
-RID load_compute_shader_from_glsl(RenderingDevice &rd, String source_text, String name) {
-	ZN_PRINT_VERBOSE(format("Creating VoxelRD compute shader {}", name));
-	// For debugging
-	// {
-	// 	Ref<FileAccess> f = FileAccess::open("debug_" + name + ".txt", FileAccess::WRITE);
-	// 	ZN_ASSERT(f.is_valid());
-	// 	f->store_string(source_text);
-	// }
+namespace {
 
+String get_voxel_compute_shader_cache_base_dir() {
+	String base_dir;
+#if defined(ZN_GODOT)
+	base_dir = Engine::get_singleton()->get_shader_cache_path();
+#endif
+	if (base_dir.is_empty()) {
+		base_dir = "user://shader_cache";
+	}
+	return base_dir;
+}
+
+String get_compute_shader_cache_dir(const String &name) {
+	return get_voxel_compute_shader_cache_base_dir()
+			.path_join(name.validate_filename());
+}
+
+String get_compute_shader_binary_cache_path(const String &source_hash, const String &device_cache_uuid, const String &name) {
+	
+	return get_compute_shader_cache_dir(name)
+			.path_join(vformat("%s.%s.bin.cache", source_hash, device_cache_uuid));
+}
+
+PackedByteArray load_compute_shader_binary_from_cache(const String &cache_file_path, const String &shader_name) {
+	if (!zylann::godot::file_exists(cache_file_path)) {
+		return PackedByteArray();
+	}
+
+	Error open_error;
+	Ref<FileAccess> file = zylann::godot::open_file(cache_file_path, FileAccess::READ, open_error);
+	if (file.is_null()) {
+		ZN_PRINT_VERBOSE(format("Could not open VoxelRD compute shader binary cache file {} for {}", cache_file_path, shader_name));
+		return PackedByteArray();
+	}
+
+	const uint64_t length = file->get_length();
+	if (length == 0) {
+		ZN_PRINT_VERBOSE(format("VoxelRD compute shader binary cache file is empty for {}", shader_name));
+		return PackedByteArray();
+	}
+
+	PackedByteArray bytes;
+	bytes.resize(length);
+	const uint64_t read_count = zylann::godot::get_buffer(**file, Span<uint8_t>(bytes.ptrw(), bytes.size()));
+	if (read_count != length) {
+		ZN_PRINT_VERBOSE(format("Could not read full VoxelRD compute shader binary cache file for {}", shader_name));
+		return PackedByteArray();
+	}
+
+	return bytes;
+}
+
+void save_compute_shader_binary_to_cache(
+		const String &cache_file_path,
+		const PackedByteArray &shader_binary,
+		const String &shader_name
+) {
+	if (shader_binary.is_empty()) {
+		return;
+	}
+
+	const Error dir_error = DirAccess::make_dir_recursive_absolute(cache_file_path.get_base_dir());
+	if (dir_error != OK) {
+		ZN_PRINT_WARNING(format("Could not create voxel compute shader binary cache directory for {}", shader_name));
+		return;
+	}
+
+	Error open_error;
+	Ref<FileAccess> file = zylann::godot::open_file(cache_file_path, FileAccess::WRITE, open_error);
+	if (file.is_null()) {
+		ZN_PRINT_WARNING(format("Could not open VoxelRD compute shader binary cache file {} for writing", cache_file_path));
+		return;
+	}
+
+	zylann::godot::store_buffer(**file, to_span(shader_binary));
+}
+
+} // namespace
+
+Ref<RDShaderSPIRV> compile_compute_shader_spirv_from_glsl(RenderingDevice &rd, String source_text, String name) {
+	// Refactored since both cache and non cache paths need this
+	
 	Ref<RDShaderSource> shader_source;
 	shader_source.instantiate();
 	shader_source->set_language(RenderingDevice::SHADER_LANGUAGE_GLSL);
 	shader_source->set_stage_source(RenderingDevice::SHADER_STAGE_COMPUTE, source_text);
 
-	// ZN_ASSERT_RETURN_MSG(
-	// 		VoxelEngine::get_singleton().has_rendering_device(),
-	// 		format("Can't create compute shader \"{}\". Maybe the selected renderer doesn't support it? ({})",
-	// 			   name,
-	// 			   zylann::godot::get_current_rendering_method())
-	// );
-	// MutexLock mlock(VoxelEngine::get_singleton().get_rendering_device_mutex());
-
 	Ref<RDShaderSPIRV> shader_spirv = zylann::godot::shader_compile_spirv_from_source(rd, **shader_source, false);
-	ERR_FAIL_COND_V(shader_spirv.is_null(), RID());
+	ERR_FAIL_COND_V(shader_spirv.is_null(), Ref<RDShaderSPIRV>());
 
-	const String error_message = shader_spirv->get_stage_compile_error(RenderingDevice::SHADER_STAGE_COMPUTE);
+	String error_message = shader_spirv->get_stage_compile_error(RenderingDevice::SHADER_STAGE_COMPUTE);
 	if (error_message != "") {
 		ERR_PRINT(String("Failed to compile compute shader '{0}'").format(varray(name)));
 		::print_line(error_message);
@@ -64,11 +136,71 @@ RID load_compute_shader_from_glsl(RenderingDevice &rd, String source_text, Strin
 			::print_line(formatted_source_text);
 		}
 
-		return RID();
+		return Ref<RDShaderSPIRV>();
 	}
 
-	// TODO What name should I give this shader? Seems it is used for caching
-	const RID shader_rid = zylann::godot::shader_create_from_spirv(rd, **shader_spirv, name);
+	return shader_spirv;
+}
+
+RID load_compute_shader_from_glsl(RenderingDevice &rd, String source_text, String name) {
+	ZN_PRINT_VERBOSE(format("Creating VoxelRD compute shader {}", name));
+	// For debugging
+	// {
+	// 	Ref<FileAccess> f = FileAccess::open("debug_" + name + ".txt", FileAccess::WRITE);
+	// 	ZN_ASSERT(f.is_valid());
+	// 	f->store_string(source_text);
+	// }
+
+	// ZN_ASSERT_RETURN_MSG(
+	// 		VoxelEngine::get_singleton().has_rendering_device(),
+	// 		format("Can't create compute shader \"{}\". Maybe the selected renderer doesn't support it? ({})",
+	// 			   name,
+	// 			   zylann::godot::get_current_rendering_method())
+	// );
+	// MutexLock mlock(VoxelEngine::get_singleton().get_rendering_device_mutex());
+
+	Ref<RDShaderSPIRV> shader_spirv = compile_compute_shader_spirv_from_glsl(rd, source_text, name);
+	ERR_FAIL_COND_V(shader_spirv.is_null(), RID());
+
+	RID shader_rid = zylann::godot::shader_create_from_spirv(rd, **shader_spirv, name);
+	ERR_FAIL_COND_V(!shader_rid.is_valid(), RID());
+
+	return shader_rid;
+}
+
+RID load_compute_shader_from_glsl_cached(RenderingDevice &rd, String source_text, String name) {
+	ZN_PRINT_VERBOSE(format("Creating VoxelRD compute shader {}", name));
+
+	const String source_hash = source_text.sha256_text();
+	const String binary_cache_file_path =
+			get_compute_shader_binary_cache_path(source_hash, rd.get_device_pipeline_cache_uuid(), name);
+
+	PackedByteArray shader_binary = load_compute_shader_binary_from_cache(binary_cache_file_path, name);
+	if (!shader_binary.is_empty()) {
+		RID shader_rid = rd.shader_create_from_bytecode(shader_binary);
+		if (shader_rid.is_valid()) {
+			ZN_PRINT_VERBOSE(format("Loaded VoxelRD compute shader {} from binary cache", name));
+			return shader_rid;
+		}
+		ZN_PRINT_VERBOSE(format("VoxelRD compute shader binary cache rejected by RenderingDevice for {}", name));
+	}
+
+	Ref<RDShaderSPIRV> shader_spirv = compile_compute_shader_spirv_from_glsl(rd, source_text, name);
+	ERR_FAIL_COND_V(shader_spirv.is_null(), RID());
+
+	shader_binary = zylann::godot::shader_compile_binary_from_spirv(rd, **shader_spirv, name);
+	ERR_FAIL_COND_V(shader_binary.is_empty(), RID());
+
+	save_compute_shader_binary_to_cache(binary_cache_file_path, shader_binary, name);
+
+	RID shader_rid = rd.shader_create_from_bytecode(shader_binary);
+	if (shader_rid.is_valid()) {
+		return shader_rid;
+	}
+
+	ZN_PRINT_VERBOSE(format("VoxelRD compute shader binary rejected by RenderingDevice for {}, falling back to SPIR-V", name));
+
+	shader_rid = zylann::godot::shader_create_from_spirv(rd, **shader_spirv, name);
 	ERR_FAIL_COND_V(!shader_rid.is_valid(), RID());
 
 	return shader_rid;
@@ -92,7 +224,14 @@ void ComputeShaderInternal::clear(RenderingDevice &rd) {
 void ComputeShaderInternal::load_from_glsl(RenderingDevice &rd, String source_text, String name) {
 	ZN_PROFILE_SCOPE();
 	clear(rd);
-	rid = load_compute_shader_from_glsl(rd, source_text, name);
+
+	ZN_ASSERT(ProjectSettings::get_singleton() != nullptr);
+	const bool shader_cache_enabled = ProjectSettings::get_singleton()->get("voxel/shaders/shader_cache/enabled");
+	if (shader_cache_enabled) {
+		rid = load_compute_shader_from_glsl_cached(rd, source_text, name);
+	} else {
+		rid = load_compute_shader_from_glsl(rd, source_text, name);
+	}
 #if DEBUG_ENABLED
 	debug_name = name;
 #endif

--- a/engine/gpu/compute_shader.cpp
+++ b/engine/gpu/compute_shader.cpp
@@ -37,7 +37,7 @@ String format_source_code_with_line_numbers(String src) {
 
 namespace {
 
-String get_voxel_compute_shader_cache_base_dir() {
+String get_compute_shader_cache_base_dir() {
 	String base_dir;
 #if defined(ZN_GODOT)
 	base_dir = Engine::get_singleton()->get_shader_cache_path();
@@ -50,7 +50,7 @@ String get_voxel_compute_shader_cache_base_dir() {
 
 String get_compute_shader_binary_cache_path(const String &source_hash, const String &device_cache_uuid, const String &name) {
 	
-	return get_voxel_compute_shader_cache_base_dir()
+	return get_compute_shader_cache_base_dir()
 			.path_join(name.validate_filename())
 			.path_join(vformat("%s.%s.bin.cache", source_hash, device_cache_uuid));
 }
@@ -214,8 +214,9 @@ void ComputeShaderInternal::load_from_glsl(RenderingDevice &rd, String source_te
 	ZN_PROFILE_SCOPE();
 	clear(rd);
 
-	ZN_ASSERT(ProjectSettings::get_singleton() != nullptr);
-	const bool shader_cache_enabled = ProjectSettings::get_singleton()->get("voxel/shaders/shader_cache/enabled");
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	ZN_ASSERT_RETURN_MSG(project_settings != nullptr, "ProjectSettings singleton is not available");
+	const bool shader_cache_enabled = project_settings->get("voxel/shaders/shader_cache/enabled");
 	rid = load_compute_shader_from_glsl(rd, source_text, name, shader_cache_enabled);
 
 #if DEBUG_ENABLED

--- a/engine/voxel_engine_gd.cpp
+++ b/engine/voxel_engine_gd.cpp
@@ -61,6 +61,8 @@ VoxelEngine::Config VoxelEngine::get_config_from_godot() {
 
 	add_custom_project_setting(Variant::BOOL, "voxel/ownership_checks", PROPERTY_HINT_NONE, "", true, true);
 
+	add_custom_project_setting(Variant::BOOL, "voxel/shaders/shader_cache/enabled", PROPERTY_HINT_NONE, "Enable the shader cache, which stores compute shader binaries for faster loading.", true, false);
+
 	config.inner.main_thread_budget_usec = 1000 * int(ps.get("voxel/threads/main/time_budget_ms"));
 
 	config.inner.thread_count_minimum = math::max(1, int(ps.get("voxel/threads/count/minimum")));

--- a/util/godot/classes/rendering_device.cpp
+++ b/util/godot/classes/rendering_device.cpp
@@ -90,44 +90,6 @@ PackedByteArray shader_compile_binary_from_spirv(RenderingDevice &rd, RDShaderSP
 #endif
 }
 
-RID shader_create_from_spirv(RenderingDevice &rd, RDShaderSPIRV &p_spirv, String name) {
-#if defined(ZN_GODOT)
-	// This is a copy of `RenderingDevice::_shader_create_from_spirv` because it's private
-
-	Vector<RenderingDevice::ShaderStageSPIRVData> stage_data;
-	for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
-		RenderingDevice::ShaderStage stage = RenderingDevice::ShaderStage(i);
-
-		String error = p_spirv.get_stage_compile_error(stage);
-		ERR_FAIL_COND_V_MSG(
-				!error.is_empty(),
-				RID(),
-				"Can't create a shader from an errored bytecode. Check errors in source bytecode."
-		);
-
-		PackedByteArray bytecode = p_spirv.get_stage_bytecode(stage);
-		if (bytecode.is_empty()) {
-			continue;
-		}
-
-		RenderingDevice::ShaderStageSPIRVData sd;
-		sd.shader_stage = stage;
-#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR <= 2
-		sd.spir_v = bytecode;
-#else
-		sd.spirv = bytecode;
-#endif
-		stage_data.push_back(sd);
-	}
-
-	return rd.shader_create_from_spirv(stage_data, name);
-
-#elif defined(ZN_GODOT_EXTENSION)
-	Ref<RDShaderSPIRV> spirv_data_ref(&p_spirv);
-	return rd.shader_create_from_spirv(spirv_data_ref, name);
-#endif
-}
-
 RID texture_create(
 		RenderingDevice &rd,
 		RDTextureFormat &p_format,

--- a/util/godot/classes/rendering_device.cpp
+++ b/util/godot/classes/rendering_device.cpp
@@ -52,6 +52,44 @@ Ref<RDShaderSPIRV> shader_compile_spirv_from_source(RenderingDevice &rd, RDShade
 #endif
 }
 
+PackedByteArray shader_compile_binary_from_spirv(RenderingDevice &rd, RDShaderSPIRV &p_spirv, String name) {
+#if defined(ZN_GODOT)
+	// This is a copy of `RenderingDevice::_shader_compile_binary_from_spirv` because it's private.
+
+	Vector<RenderingDevice::ShaderStageSPIRVData> stage_data;
+	for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
+		RenderingDevice::ShaderStage stage = RenderingDevice::ShaderStage(i);
+
+		String error = p_spirv.get_stage_compile_error(stage);
+		ERR_FAIL_COND_V_MSG(
+				!error.is_empty(),
+				PackedByteArray(),
+				"Can't create a shader from an errored bytecode. Check errors in source bytecode."
+		);
+
+		PackedByteArray bytecode = p_spirv.get_stage_bytecode(stage);
+		if (bytecode.is_empty()) {
+			continue;
+		}
+
+		RenderingDevice::ShaderStageSPIRVData sd;
+		sd.shader_stage = stage;
+#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR <= 2
+		sd.spir_v = bytecode;
+#else
+		sd.spirv = bytecode;
+#endif
+		stage_data.push_back(sd);
+	}
+
+	return rd.shader_compile_binary_from_spirv(stage_data, name);
+
+#elif defined(ZN_GODOT_EXTENSION)
+	Ref<RDShaderSPIRV> spirv_data_ref(&p_spirv);
+	return rd.shader_compile_binary_from_spirv(spirv_data_ref, name);
+#endif
+}
+
 RID shader_create_from_spirv(RenderingDevice &rd, RDShaderSPIRV &p_spirv, String name) {
 #if defined(ZN_GODOT)
 	// This is a copy of `RenderingDevice::_shader_create_from_spirv` because it's private

--- a/util/godot/classes/rendering_device.h
+++ b/util/godot/classes/rendering_device.h
@@ -21,6 +21,7 @@ void free_rendering_device_rid(RenderingDevice &rd, RID rid);
 // This forces me to copy implementations to keep my code the same in both module and extension targets
 
 Ref<RDShaderSPIRV> shader_compile_spirv_from_source(RenderingDevice &rd, RDShaderSource &p_source, bool p_allow_cache);
+PackedByteArray shader_compile_binary_from_spirv(RenderingDevice &rd, RDShaderSPIRV &p_spirv, String name = "");
 RID shader_create_from_spirv(RenderingDevice &rd, RDShaderSPIRV &p_spirv, String name = "");
 RID texture_create(
 		RenderingDevice &rd,

--- a/util/godot/classes/rendering_device.h
+++ b/util/godot/classes/rendering_device.h
@@ -22,7 +22,6 @@ void free_rendering_device_rid(RenderingDevice &rd, RID rid);
 
 Ref<RDShaderSPIRV> shader_compile_spirv_from_source(RenderingDevice &rd, RDShaderSource &p_source, bool p_allow_cache);
 PackedByteArray shader_compile_binary_from_spirv(RenderingDevice &rd, RDShaderSPIRV &p_spirv, String name = "");
-RID shader_create_from_spirv(RenderingDevice &rd, RDShaderSPIRV &p_spirv, String name = "");
 RID texture_create(
 		RenderingDevice &rd,
 		RDTextureFormat &p_format,


### PR DESCRIPTION
Providing a PR at this stage for feedback and discussion, with the understanding that there are a few things to test (see test section). It's a pretty neat performance improvement so I hope it's worth merging. 

**Problem Statement** 
When developing the script graph generator I couldn't get it to start rendering before around 5-8s after start. All of my metrics assumed the shader compile time was fixed and long. 

**Root Cause** 
Godot caches shaders except for compute shaders. The fix should probably go in the Godot engine but it would require new infrastructure. 

**Fix Method** 
The previous method was to use shader_create_from_spirv, which calls an internal method _shader_compile_binary_from_spirv followed by shader_create_from_bytecode. 

The fix does a similar duplication in the utils for _shader_compile_binary_from_spirv  to expose the raw binary using RDShaderSPIRV rather than ShaderStageSPIRVData. Then saves it to a buffer, and checks the cache based on the shader source hash and get_pipeline_cache_uuid() (from the documentation this gates against gpu and driver version changes, invalidating the cache). 

In addition, a new shader cache flag was added to the voxel project settings. 

If the flag is false, load_compute_shader_from_glsl is used as it was. If it is enabled, load_compute_shader_from_glsl_cached is called which does the caching and loading logic. The verbose logs will note when cached materials are loaded. 

In the GDExtension, shader_compile_binary_from_spirv is used directly. 

**Testing Performed**
- Time to "Creating VoxelRD pooled storage buffer 36b" text in the logs dropped from around 8s uncached to 0.75s cached on start. 

- I confirmed it builds in modules and gdextension. Using Godot 4.6. 

- I still need to run the tests, and drop the gdextension in a project to confirm, and check in godot 4.7

**Use of AI** 
I used AI, limited to tab complete and providing search utilities (eg, to explain and compare existing cache methods to align with engine methods for shader caching). Most of the code itself was just shuffled around between the engine and voxel module.

**Use of Other Copyright Materials**
I didn't use any materials that were not in the Godot engine. 

