### PR TITLE
Fix GPU unsupported warning timing

### DIFF
--- a/engine/gpu/gpu_task_runner.cpp
+++ b/engine/gpu/gpu_task_runner.cpp
@@ -68,10 +68,6 @@ unsigned int GPUTaskRunner::get_pending_task_count() const {
 // 	return _rendering_device;
 // }
 
-bool GPUTaskRunner::has_rendering_device() const {
-	return _has_rendering_device;
-}
-
 void GPUTaskRunner::thread_func() {
 	ZN_PROFILE_SET_THREAD_NAME("Voxel GPU tasks");
 	ZN_DSTACK();
@@ -89,8 +85,6 @@ void GPUTaskRunner::thread_func() {
 		ZN_PRINT_VERBOSE("Could not create local RenderingDevice, GPU functionality won't be supported.");
 		return;
 	}
-
-	_has_rendering_device = true;
 
 	_storage_buffer_pool.set_rendering_device(_rendering_device);
 	_base_resources.load(*_rendering_device);

--- a/engine/gpu/gpu_task_runner.h
+++ b/engine/gpu/gpu_task_runner.h
@@ -79,7 +79,6 @@ public:
 	void stop();
 	void push(IGPUTask *task);
 	unsigned int get_pending_task_count() const;
-	bool has_rendering_device() const;
 	bool is_running() const;
 
 private:
@@ -87,7 +86,6 @@ private:
 
 	RenderingDevice *_rendering_device = nullptr;
 	// mutable Mutex _rendering_device_ptr_mutex;
-	bool _has_rendering_device = false;
 
 	GPUStorageBufferPool _storage_buffer_pool;
 	BaseGPUResources _base_resources;

--- a/engine/voxel_engine.cpp
+++ b/engine/voxel_engine.cpp
@@ -8,7 +8,6 @@
 #include "../util/godot/classes/os.h"
 #include "../util/godot/classes/project_settings.h"
 #include "../util/godot/classes/rd_sampler_state.h"
-#include "../util/godot/classes/rendering_device.h"
 #include "../util/godot/classes/rendering_server.h"
 #include "../util/io/log.h"
 #include "../util/macros.h"
@@ -288,20 +287,6 @@ void VoxelEngine::push_async_io_tasks(Span<zylann::IThreadedTask *> tasks) {
 }
 
 #ifdef VOXEL_ENABLE_GPU
-bool VoxelEngine::supports_gpu_generation() const {
-	RenderingServer *rs = RenderingServer::get_singleton();
-	if (rs == nullptr) {
-		return false;
-	}
-
-	RenderingDevice *rd = rs->get_rendering_device();
-	if (rd == nullptr) {
-		return false;
-	}
-
-	return true;
-}
-
 void VoxelEngine::push_gpu_task(IGPUTask *task) {
 	_gpu_task_runner.push(task);
 }

--- a/engine/voxel_engine.cpp
+++ b/engine/voxel_engine.cpp
@@ -288,6 +288,20 @@ void VoxelEngine::push_async_io_tasks(Span<zylann::IThreadedTask *> tasks) {
 }
 
 #ifdef VOXEL_ENABLE_GPU
+bool VoxelEngine::supports_gpu_generation() const {
+	RenderingServer *rs = RenderingServer::get_singleton();
+	if (rs == nullptr) {
+		return false;
+	}
+
+	RenderingDevice *rd = rs->get_rendering_device();
+	if (rd == nullptr) {
+		return false;
+	}
+
+	return true;
+}
+
 void VoxelEngine::push_gpu_task(IGPUTask *task) {
 	_gpu_task_runner.push(task);
 }

--- a/engine/voxel_engine.h
+++ b/engine/voxel_engine.h
@@ -222,7 +222,6 @@ public:
 	void push_async_io_tasks(Span<IThreadedTask *> tasks);
 
 #ifdef VOXEL_ENABLE_GPU
-	bool supports_gpu_generation() const;
 	void push_gpu_task(IGPUTask *task);
 
 	template <typename F>

--- a/engine/voxel_engine.h
+++ b/engine/voxel_engine.h
@@ -222,6 +222,7 @@ public:
 	void push_async_io_tasks(Span<IThreadedTask *> tasks);
 
 #ifdef VOXEL_ENABLE_GPU
+	bool supports_gpu_generation() const;
 	void push_gpu_task(IGPUTask *task);
 
 	template <typename F>
@@ -276,12 +277,6 @@ public:
 
 	int get_thread_count() const;
 	void set_thread_count(uint32_t count);
-
-#ifdef VOXEL_ENABLE_GPU
-	bool has_rendering_device() const {
-		return _gpu_task_runner.has_rendering_device();
-	}
-#endif
 
 	// RenderingDevice &get_rendering_device() const {
 	// 	ZN_ASSERT(_rendering_device != nullptr);

--- a/terrain/variable_lod/voxel_lod_terrain.cpp
+++ b/terrain/variable_lod/voxel_lod_terrain.cpp
@@ -48,6 +48,10 @@
 #include "../../util/godot/core/class_db.h"
 #endif
 
+#ifdef VOXEL_ENABLE_GPU
+#include "../../util/godot/classes/rendering_server.h"
+#endif
+
 namespace zylann::voxel {
 
 namespace {
@@ -2960,7 +2964,7 @@ void VoxelLodTerrain::get_configuration_warnings(PackedStringArray &warnings) co
 			warnings.append(String("`use_gpu_generation` is enabled, but {0} does not support running on the GPU.")
 									.format(varray(generator->get_class())));
 		}
-		if (!VoxelEngine::get_singleton().supports_gpu_generation()) {
+		if (!zylann::godot::supports_gpu_generation()) {
 			warnings.append(String("`use_gpu_generation` is enabled, but the selected renderer does not support the "
 								   "RenderingDevice API ({0}).")
 									.format(varray(get_current_rendering_method())));

--- a/terrain/variable_lod/voxel_lod_terrain.cpp
+++ b/terrain/variable_lod/voxel_lod_terrain.cpp
@@ -2960,7 +2960,7 @@ void VoxelLodTerrain::get_configuration_warnings(PackedStringArray &warnings) co
 			warnings.append(String("`use_gpu_generation` is enabled, but {0} does not support running on the GPU.")
 									.format(varray(generator->get_class())));
 		}
-		if (!VoxelEngine::get_singleton().has_rendering_device()) {
+		if (!VoxelEngine::get_singleton().supports_gpu_generation()) {
 			warnings.append(String("`use_gpu_generation` is enabled, but the selected renderer does not support the "
 								   "RenderingDevice API ({0}).")
 									.format(varray(get_current_rendering_method())));

--- a/terrain/variable_lod/voxel_lod_terrain.cpp
+++ b/terrain/variable_lod/voxel_lod_terrain.cpp
@@ -2964,7 +2964,7 @@ void VoxelLodTerrain::get_configuration_warnings(PackedStringArray &warnings) co
 			warnings.append(String("`use_gpu_generation` is enabled, but {0} does not support running on the GPU.")
 									.format(varray(generator->get_class())));
 		}
-		if (!zylann::godot::supports_gpu_generation()) {
+		if (!zylann::godot::supports_rendering_device()) {
 			warnings.append(String("`use_gpu_generation` is enabled, but the selected renderer does not support the "
 								   "RenderingDevice API ({0}).")
 									.format(varray(get_current_rendering_method())));

--- a/util/godot/classes/rendering_server.h
+++ b/util/godot/classes/rendering_server.h
@@ -44,7 +44,7 @@ inline void free_rendering_server_rid(RenderingServer &rs, const RID &rid) {
 }
 
 #ifdef VOXEL_ENABLE_GPU
-inline bool supports_gpu_generation() {
+inline bool supports_rendering_device() {
 	RenderingServer *rs = RenderingServer::get_singleton();
 	if (rs == nullptr) {
 		return false;

--- a/util/godot/classes/rendering_server.h
+++ b/util/godot/classes/rendering_server.h
@@ -43,6 +43,17 @@ inline void free_rendering_server_rid(RenderingServer &rs, const RID &rid) {
 #endif
 }
 
+#ifdef VOXEL_ENABLE_GPU
+inline bool supports_gpu_generation() {
+	RenderingServer *rs = RenderingServer::get_singleton();
+	if (rs == nullptr) {
+		return false;
+	}
+
+	return rs->get_rendering_device() != nullptr;
+}
+#endif
+
 struct ShaderParameterInfo {
 	String name;
 	Variant::Type type;


### PR DESCRIPTION
Fixing a minor nuisance, 

**Problem Statement**
When starting the editor containing a VoxelLodTerrain using GPU generation, it gives a spurious warning

`use_gpu_generation` is enabled, but the selected renderer does not support the RenderingDevice API

And then proceeds to use GPU to run stuff anyway, since this is a timing issue. 

**Root Cause**
The function VoxelLodTerrain::get_configuration_warnings calls VoxelEngine::get_singleton().has_rendering_device()

This returns true if the GPUTaskRunner has created a local rendering device. 

In order to determine if GPU compute is supported, we need to know if the RenderingDevice API is supported. 

> Compute shaders can only be used from RenderingDevice-based renderers (the Forward+ or Mobile renderer). (from compute documentation)

So ideally this would query the earliest available rendering device - which is the global one under RenderingServer (singleton = this) if you are going to use the existence of a RenderingDevice as the basis. 

A quick timing check on master confirms this happens way before the config check

```
t_us=126070  RenderingDevice singleton assigned
t_us=3127221 RenderingServer::get_rendering_device() during VoxelLodTerrain warnings: ready
t_us=3127264 VoxelLodTerrain registers RenderingDevice API configuration warning
t_us=3240435 GPUTaskRunner first got local RenderingDevice
```

**Fix Method**
In VoxelEngine, Replaced the has_rendering_device with supports_gpu_generation().

supports_gpu_generation now just gets the RenderingServer singleton, which should by then, have a RenderingDevice singleton. This is the global rendering device and is the earliest indication (absent a feature or renderer tag or something) that GPU compute is supported. 

Since has_rendering_device and related calls were redundant, removed them. 

**Alternatives**
- I was curious if there was a more direct method in the godot engine, and there does not seem to be a flag or anything that would replace the implementation in VoxelEngine

- I considered enumerating renderers or something (finding Forward+ or Mobile enums) but this is fragile. It's cited as "RenderingDevice supports GPU compute" and separately, forward+ and mobile use RenderingDevice, but there's no guarantee this will always be the case so RenderingDevice query seems the most direct (and close to what we already have)

- VoxelTerrain doesn't have the same issue because it doesn't add the same warning. So we could also just remove the warning if it's not uniform. It may be a good time to bring it to VoxelTerrain, except, it's not clear if that one is actively maintained. 
 
**Testing Performed**

Timing analysis performed (see above), tested on 4.7 module version and 4.6.1 reference build w/ gdextension. 

bin\godot.windows.editor.x86_64.console.exe --path modules\voxel\project --rendering-method forward_plus --verbose --editor res://check_gpu_warning.tscn

supports_gpu_generation return

| Rendering Method | Module | GDExtension |
|---|---|---|
| `forward_plus` | true | true |
| `mobile` | true | true |
| `gl_compatibility` | false | false |

**Use of AI**
I used AI to search and generate timing prints, but wrote the code and PR summary myself (there wasn't much to code tbh)

**Use of Other Copyright Materials**
I didn't use any other materials at all.


