### PR TITLE
SQLite: fix connections getting stuck inside a transaction under concurrent access

### DIFF
--- a/streams/sqlite/connection.cpp
+++ b/streams/sqlite/connection.cpp
@@ -156,6 +156,15 @@ struct TransactionScope {
 	}
 };
 
+// How long a connection waits for a lock held by another connection before giving up with SQLITE_BUSY.
+// Several connections of the same stream can be open on the same file at once (see VoxelStreamSQLite's connection
+// pool), so they do contend: a background streaming thread loading blocks, and a `flush()` called from game code,
+// for example. Transactions here are bounded (a cache flush writes at most VoxelStreamSQLite::CACHE_SIZE blocks), so
+// realistic waits are much shorter than this; the timeout is a safety net rather than an expected cost. It is kept
+// modest because `flush()` is callable from the main thread, where a long block would be a visible freeze, and
+// because exceeding it is no longer fatal: callers recover the connection with `rollback_transaction`.
+const int TRANSACTION_BUSY_TIMEOUT_MS = 1000;
+
 static bool prepare(sqlite3 *db, sqlite3_stmt **s, const char *sql) {
 	const int rc = sqlite3_prepare_v2(db, sql, -1, s, nullptr);
 	if (rc != SQLITE_OK) {
@@ -190,6 +199,10 @@ bool Connection::open(const char *fpath, const BlockLocation::CoordinateFormat p
 		close();
 		return false;
 	}
+
+	// Without a busy handler, any statement that can't take a lock held by another connection fails immediately
+	// instead of waiting for it. That notably affects COMMIT, which leaves the transaction open when it fails.
+	sqlite3_busy_timeout(_db, TRANSACTION_BUSY_TIMEOUT_MS);
 
 	// Note, SQLite uses UTF-8 encoding by default. We rely on that.
 	// https://www.sqlite.org/c3ref/open.html
@@ -265,6 +278,9 @@ bool Connection::open(const char *fpath, const BlockLocation::CoordinateFormat p
 		return false;
 	}
 	if (!prepare(db, &_end_statement, "END")) {
+		return false;
+	}
+	if (!prepare(db, &_rollback_statement, "ROLLBACK")) {
 		return false;
 	}
 	if (!prepare(db, &_load_meta_statement, "SELECT * FROM meta")) {
@@ -352,6 +368,7 @@ void Connection::close() {
 	}
 	finalize(_begin_statement);
 	finalize(_end_statement);
+	finalize(_rollback_statement);
 	finalize(_load_version_statement);
 	finalize(_update_voxel_block_statement);
 	finalize(_get_voxel_block_statement);
@@ -396,6 +413,37 @@ bool Connection::end_transaction() {
 		return false;
 	}
 	rc = sqlite3_step(_end_statement);
+	if (rc != SQLITE_DONE) {
+		ERR_PRINT(sqlite3_errmsg(_db));
+		return false;
+	}
+	return true;
+}
+
+bool Connection::rollback_transaction() {
+	if (_db == nullptr) {
+		return false;
+	}
+
+	// `sqlite3_reset` returns the error code of the *previous* evaluation of the statement, so a statement that
+	// failed once keeps reporting that same failure the next time it is used, even though the reset itself did
+	// happen. Clear that leftover state here, otherwise the recovered connection would spuriously fail its next
+	// `begin_transaction`.
+	sqlite3_reset(_begin_statement);
+	sqlite3_reset(_end_statement);
+
+	// No transaction is active, so there is nothing to roll back. Issuing ROLLBACK anyway would fail with
+	// "cannot rollback - no transaction is active".
+	if (sqlite3_get_autocommit(_db) != 0) {
+		return true;
+	}
+
+	int rc = sqlite3_reset(_rollback_statement);
+	if (rc != SQLITE_OK) {
+		ERR_PRINT(sqlite3_errmsg(_db));
+		return false;
+	}
+	rc = sqlite3_step(_rollback_statement);
 	if (rc != SQLITE_DONE) {
 		ERR_PRINT(sqlite3_errmsg(_db));
 		return false;

--- a/streams/sqlite/connection.cpp
+++ b/streams/sqlite/connection.cpp
@@ -148,11 +148,21 @@ inline bool read_block_location(
 
 struct TransactionScope {
 	Connection &db;
+	bool began;
 	TransactionScope(Connection &p_db) : db(p_db) {
-		db.begin_transaction();
+		began = db.begin_transaction();
+		if (!began) {
+			// Attempt to clear any leftover transaction state so the connection remains usable. The scoped
+			// queries will still run, just not atomically.
+			db.rollback_transaction();
+		}
 	}
 	~TransactionScope() {
-		db.end_transaction();
+		if (began && !db.end_transaction()) {
+			// A COMMIT that fails (SQLITE_BUSY notably) leaves the transaction open, which would make every
+			// later BEGIN on this connection fail. Roll it back so the connection can be reused.
+			db.rollback_transaction();
+		}
 	}
 };
 

--- a/streams/sqlite/connection.h
+++ b/streams/sqlite/connection.h
@@ -60,6 +60,12 @@ public:
 	bool begin_transaction();
 	bool end_transaction();
 
+	// Rolls back a transaction that may still be active on this connection, and clears leftover error state on the
+	// transaction statements. Use this to recover a connection after `begin_transaction` or `end_transaction`
+	// failed, so it can be reused. Returns false if the connection could not be recovered, in which case it must not
+	// be reused. Safe to call when no transaction is active.
+	bool rollback_transaction();
+
 	bool save_block(const BlockLocation loc, const Span<const uint8_t> block_data, const BlockType type);
 
 	VoxelStream::ResultCode load_block(
@@ -102,6 +108,7 @@ private:
 	sqlite3_stmt *_load_version_statement = nullptr;
 	sqlite3_stmt *_begin_statement = nullptr;
 	sqlite3_stmt *_end_statement = nullptr;
+	sqlite3_stmt *_rollback_statement = nullptr;
 	sqlite3_stmt *_update_voxel_block_statement = nullptr;
 	sqlite3_stmt *_get_voxel_block_statement = nullptr;
 	sqlite3_stmt *_update_instance_block_statement = nullptr;

--- a/streams/sqlite/voxel_stream_sqlite.cpp
+++ b/streams/sqlite/voxel_stream_sqlite.cpp
@@ -36,6 +36,18 @@ VoxelStreamSQLite::CoordinateFormat to_exposed_coordinate_format(BlockLocation::
 	return static_cast<VoxelStreamSQLite::CoordinateFormat>(format);
 }
 
+// Brings a connection back to a usable state after a transaction failed on it, and tells whether it may be reused.
+// A failed COMMIT notably leaves the transaction open, and SQLite has no nested transactions, so without this every
+// later `begin_transaction` on that connection would fail with "cannot start a transaction within a transaction".
+bool recover_after_failed_transaction(sqlite::Connection &con) {
+	if (con.rollback_transaction()) {
+		ZN_PRINT_VERBOSE("VoxelStreamSQLite: recovered connection after a failed transaction");
+		return true;
+	}
+	ZN_PRINT_ERROR("VoxelStreamSQLite: could not recover connection after a failed transaction, dropping it");
+	return false;
+}
+
 bool validate_range(Vector3i pos, unsigned int lod_index, const Box3i coordinate_range, unsigned int lod_count) {
 	if (!coordinate_range.contains(pos)) {
 		ZN_PRINT_ERROR(format("Block position {} is outside of supported range {}", pos, coordinate_range));
@@ -79,6 +91,8 @@ void VoxelStreamSQLite::set_database_path(String path) {
 		// Since Godot helpfully sets the property for every character typed in the inspector.
 		// So there can be lots of errors in the editor if you type it.
 		if (con.open(_globalized_connection_path.data(), to_internal_coordinate_format(_preferred_coordinate_format))) {
+			// Failure deliberately not handled: the connection is local and destroyed right after, so there is
+			// nothing to recover, and the path is changing anyway.
 			flush_cache_to_connection(&con);
 		}
 	}
@@ -142,7 +156,7 @@ void VoxelStreamSQLite::load_voxel_blocks(Span<VoxelStream::VoxelQueryData> p_bl
 
 	sqlite::Connection *con = con_res.connection;
 
-	const ScopeRecycle con_scope(this, con);
+	ScopeRecycle con_scope(this, con);
 
 	// Check the cache first
 	StdVector<unsigned int> blocks_to_load;
@@ -168,8 +182,10 @@ void VoxelStreamSQLite::load_voxel_blocks(Span<VoxelStream::VoxelQueryData> p_bl
 		return;
 	}
 
-	// TODO We should handle busy return codes
-	ERR_FAIL_COND(con->begin_transaction() == false);
+	if (con->begin_transaction() == false) {
+		con_scope.broken = !recover_after_failed_transaction(*con);
+		return;
+	}
 
 	for (unsigned int i = 0; i < blocks_to_load.size(); ++i) {
 		const unsigned int ri = blocks_to_load[i];
@@ -191,7 +207,9 @@ void VoxelStreamSQLite::load_voxel_blocks(Span<VoxelStream::VoxelQueryData> p_bl
 		q.result = res;
 	}
 
-	ERR_FAIL_COND(con->end_transaction() == false);
+	if (con->end_transaction() == false) {
+		con_scope.broken = !recover_after_failed_transaction(*con);
+	}
 }
 
 void VoxelStreamSQLite::save_voxel_blocks(Span<VoxelStream::VoxelQueryData> p_blocks) {
@@ -277,10 +295,12 @@ void VoxelStreamSQLite::load_instance_blocks(Span<VoxelStream::InstancesQueryDat
 	}
 
 	sqlite::Connection *con = con_res.connection;
-	const ScopeRecycle con_scope(this, con);
+	ScopeRecycle con_scope(this, con);
 
-	// TODO We should handle busy return codes
-	ERR_FAIL_COND(con->begin_transaction() == false);
+	if (con->begin_transaction() == false) {
+		con_scope.broken = !recover_after_failed_transaction(*con);
+		return;
+	}
 
 	for (unsigned int i = 0; i < blocks_to_load.size(); ++i) {
 		const unsigned int ri = blocks_to_load[i];
@@ -313,7 +333,9 @@ void VoxelStreamSQLite::load_instance_blocks(Span<VoxelStream::InstancesQueryDat
 		q.result = res;
 	}
 
-	ERR_FAIL_COND(con->end_transaction() == false);
+	if (con->end_transaction() == false) {
+		con_scope.broken = !recover_after_failed_transaction(*con);
+	}
 }
 
 void VoxelStreamSQLite::save_instance_blocks(Span<VoxelStream::InstancesQueryData> p_blocks) {
@@ -450,8 +472,10 @@ void VoxelStreamSQLite::flush_cache() {
 	}
 	sqlite::Connection *con = con_res.connection;
 
-	const ScopeRecycle con_scope(this, con);
-	flush_cache_to_connection(con);
+	ScopeRecycle con_scope(this, con);
+	if (!flush_cache_to_connection(con)) {
+		con_scope.broken = !recover_after_failed_transaction(*con);
+	}
 }
 
 void VoxelStreamSQLite::flush() {
@@ -459,12 +483,16 @@ void VoxelStreamSQLite::flush() {
 }
 
 // This function does not lock any mutex for internal use.
-void VoxelStreamSQLite::flush_cache_to_connection(sqlite::Connection *p_connection) {
+// Returns false if the transaction failed, in which case the connection may need to be recovered before reuse (see
+// `recover_after_failed_transaction`).
+bool VoxelStreamSQLite::flush_cache_to_connection(sqlite::Connection *p_connection) {
 	ZN_PROFILE_SCOPE();
 	ZN_PRINT_VERBOSE(format("VoxelStreamSQLite: Flushing cache ({} elements)", _cache.get_indicative_block_count()));
 
-	ERR_FAIL_COND(p_connection == nullptr);
-	ERR_FAIL_COND(p_connection->begin_transaction() == false);
+	ERR_FAIL_COND_V(p_connection == nullptr, false);
+	if (p_connection->begin_transaction() == false) {
+		return false;
+	}
 
 #ifdef VOXEL_ENABLE_INSTANCER
 	StdVector<uint8_t> &temp_data = get_tls_temp_block_data();
@@ -522,7 +550,11 @@ void VoxelStreamSQLite::flush_cache_to_connection(sqlite::Connection *p_connecti
 		// TODO Optimization: add a version of the query that can update both at once
 	});
 
-	ERR_FAIL_COND(p_connection->end_transaction() == false);
+	if (p_connection->end_transaction() == false) {
+		return false;
+	}
+
+	return true;
 }
 
 VoxelStreamSQLite::ConnectionResult VoxelStreamSQLite::get_connection() {
@@ -574,6 +606,12 @@ void VoxelStreamSQLite::recycle_connection(sqlite::Connection *con) {
 			return;
 		}
 	}
+	delete con;
+}
+
+void VoxelStreamSQLite::destroy_connection(sqlite::Connection *con) {
+	// Defined here rather than inline in the header, where `Connection` is only forward-declared and its destructor
+	// would therefore not run.
 	delete con;
 }
 

--- a/streams/sqlite/voxel_stream_sqlite.cpp
+++ b/streams/sqlite/voxel_stream_sqlite.cpp
@@ -68,7 +68,10 @@ VoxelStreamSQLite::~VoxelStreamSQLite() {
 	ZN_PRINT_VERBOSE("~VoxelStreamSQLite");
 	if (!_globalized_connection_path.empty() && _cache.get_indicative_block_count() > 0) {
 		ZN_PRINT_VERBOSE("~VoxelStreamSQLite flushy flushy");
-		flush_cache();
+		if (!flush_cache()) {
+			// Last chance to save that data: past this point it is lost.
+			ZN_PRINT_ERROR("VoxelStreamSQLite: final flush failed in destructor, unsaved cached data was lost");
+		}
 		ZN_PRINT_VERBOSE("~VoxelStreamSQLite flushy done");
 	}
 	for (auto it = _connection_pool.begin(); it != _connection_pool.end(); ++it) {
@@ -91,9 +94,14 @@ void VoxelStreamSQLite::set_database_path(String path) {
 		// Since Godot helpfully sets the property for every character typed in the inspector.
 		// So there can be lots of errors in the editor if you type it.
 		if (con.open(_globalized_connection_path.data(), to_internal_coordinate_format(_preferred_coordinate_format))) {
-			// Failure deliberately not handled: the connection is local and destroyed right after, so there is
-			// nothing to recover, and the path is changing anyway.
-			flush_cache_to_connection(&con);
+			if (!flush_cache_to_connection(&con)) {
+				// The connection is local and destroyed right after, so there is nothing to recover, but the
+				// data could not be saved to the previous database before switching away from it.
+				ZN_PRINT_ERROR(
+						"VoxelStreamSQLite: failed to save cached data to the previous database before "
+						"changing the path"
+				);
+			}
 		}
 	}
 	for (auto it = _connection_pool.begin(); it != _connection_pool.end(); ++it) {
@@ -183,6 +191,10 @@ void VoxelStreamSQLite::load_voxel_blocks(Span<VoxelStream::VoxelQueryData> p_bl
 	}
 
 	if (con->begin_transaction() == false) {
+		ZN_PRINT_ERROR("VoxelStreamSQLite: failed to begin transaction, blocks were not loaded");
+		for (const unsigned int ri : blocks_to_load) {
+			p_blocks[ri].result = RESULT_ERROR;
+		}
 		con_scope.broken = !recover_after_failed_transaction(*con);
 		return;
 	}
@@ -208,6 +220,9 @@ void VoxelStreamSQLite::load_voxel_blocks(Span<VoxelStream::VoxelQueryData> p_bl
 	}
 
 	if (con->end_transaction() == false) {
+		// The transaction only read data, and results were already copied out above, so they remain valid.
+		// Only the connection needs attention.
+		ZN_PRINT_ERROR("VoxelStreamSQLite: failed to end read transaction, recovering the connection");
 		con_scope.broken = !recover_after_failed_transaction(*con);
 	}
 }
@@ -248,7 +263,11 @@ void VoxelStreamSQLite::save_voxel_blocks(Span<VoxelStream::VoxelQueryData> p_bl
 
 	// TODO We should consider using a serialized cache, and measure the threshold in bytes
 	if (_cache.get_indicative_block_count() >= CACHE_SIZE) {
-		flush_cache();
+		if (!flush_cache()) {
+			// Recoverable: blocks stay cached (unless the commit itself failed, which reported above), and the
+			// next save that grows the cache past the threshold will retry.
+			ZN_PRINT_WARNING("VoxelStreamSQLite: automatic cache flush did not complete, will retry later");
+		}
 	}
 }
 
@@ -298,6 +317,10 @@ void VoxelStreamSQLite::load_instance_blocks(Span<VoxelStream::InstancesQueryDat
 	ScopeRecycle con_scope(this, con);
 
 	if (con->begin_transaction() == false) {
+		ZN_PRINT_ERROR("VoxelStreamSQLite: failed to begin transaction, instance blocks were not loaded");
+		for (const unsigned int ri : blocks_to_load) {
+			out_blocks[ri].result = RESULT_ERROR;
+		}
 		con_scope.broken = !recover_after_failed_transaction(*con);
 		return;
 	}
@@ -334,6 +357,9 @@ void VoxelStreamSQLite::load_instance_blocks(Span<VoxelStream::InstancesQueryDat
 	}
 
 	if (con->end_transaction() == false) {
+		// The transaction only read data, and results were already copied out above, so they remain valid.
+		// Only the connection needs attention.
+		ZN_PRINT_ERROR("VoxelStreamSQLite: failed to end read transaction, recovering the connection");
 		con_scope.broken = !recover_after_failed_transaction(*con);
 	}
 }
@@ -372,7 +398,11 @@ void VoxelStreamSQLite::save_instance_blocks(Span<VoxelStream::InstancesQueryDat
 
 	// TODO Optimization: we should consider using a serialized cache, and measure the threshold in bytes
 	if (_cache.get_indicative_block_count() >= CACHE_SIZE) {
-		flush_cache();
+		if (!flush_cache()) {
+			// Recoverable: blocks stay cached (unless the commit itself failed, which reported above), and the
+			// next save that grows the cache past the threshold will retry.
+			ZN_PRINT_WARNING("VoxelStreamSQLite: automatic cache flush did not complete, will retry later");
+		}
 	}
 }
 
@@ -460,26 +490,30 @@ int VoxelStreamSQLite::get_used_channels_mask() const {
 	return VoxelBuffer::ALL_CHANNELS_MASK;
 }
 
-void VoxelStreamSQLite::flush_cache() {
+bool VoxelStreamSQLite::flush_cache() {
 	const ConnectionResult con_res = get_connection();
 	switch (con_res.code) {
 		case ConnectionResult::SUCCESS:
 			break;
 		case ConnectionResult::NOT_CONFIGURED:
-			return;
+			return false;
 		default:
-			return;
+			return false;
 	}
 	sqlite::Connection *con = con_res.connection;
 
 	ScopeRecycle con_scope(this, con);
-	if (!flush_cache_to_connection(con)) {
+	const bool success = flush_cache_to_connection(con);
+	if (!success) {
 		con_scope.broken = !recover_after_failed_transaction(*con);
 	}
+	return success;
 }
 
 void VoxelStreamSQLite::flush() {
-	flush_cache();
+	if (!flush_cache()) {
+		ZN_PRINT_ERROR("VoxelStreamSQLite: flush did not complete");
+	}
 }
 
 // This function does not lock any mutex for internal use.
@@ -491,6 +525,9 @@ bool VoxelStreamSQLite::flush_cache_to_connection(sqlite::Connection *p_connecti
 
 	ERR_FAIL_COND_V(p_connection == nullptr, false);
 	if (p_connection->begin_transaction() == false) {
+		// Nothing was written or dropped at this point: cached blocks are retained, so a later flush will retry
+		// them. Detailed reporting is left to callers, which know their context.
+		ZN_PRINT_VERBOSE("VoxelStreamSQLite: could not begin flush transaction, keeping cached blocks");
 		return false;
 	}
 
@@ -551,6 +588,9 @@ bool VoxelStreamSQLite::flush_cache_to_connection(sqlite::Connection *p_connecti
 	});
 
 	if (p_connection->end_transaction() == false) {
+		// The cache was already drained into this transaction, so these blocks are dropped without being saved.
+		// This is the lossy case, unlike a failed begin above.
+		ZN_PRINT_ERROR("VoxelStreamSQLite: failed to commit flush transaction, unsaved cached blocks were dropped");
 		return false;
 	}
 

--- a/streams/sqlite/voxel_stream_sqlite.cpp
+++ b/streams/sqlite/voxel_stream_sqlite.cpp
@@ -144,6 +144,18 @@ static void set_result_codes(Span<VoxelStream::InstancesQueryData> p_blocks, Vox
 }
 #endif
 
+// Only sets the given subset, leaving blocks already resolved from the cache untouched.
+template <typename TBlockQueryData>
+static void set_result_codes(
+		Span<TBlockQueryData> p_blocks,
+		const StdVector<unsigned int> &p_indices,
+		const VoxelStream::ResultCode code
+) {
+	for (const unsigned int i : p_indices) {
+		p_blocks[i].result = code;
+	}
+}
+
 void VoxelStreamSQLite::load_voxel_blocks(Span<VoxelStream::VoxelQueryData> p_blocks) {
 	ZN_PROFILE_SCOPE();
 
@@ -192,9 +204,7 @@ void VoxelStreamSQLite::load_voxel_blocks(Span<VoxelStream::VoxelQueryData> p_bl
 
 	if (con->begin_transaction() == false) {
 		ZN_PRINT_ERROR("VoxelStreamSQLite: failed to begin transaction, blocks were not loaded");
-		for (const unsigned int ri : blocks_to_load) {
-			p_blocks[ri].result = RESULT_ERROR;
-		}
+		set_result_codes(p_blocks, blocks_to_load, RESULT_ERROR);
 		con_scope.broken = !recover_after_failed_transaction(*con);
 		return;
 	}
@@ -318,9 +328,7 @@ void VoxelStreamSQLite::load_instance_blocks(Span<VoxelStream::InstancesQueryDat
 
 	if (con->begin_transaction() == false) {
 		ZN_PRINT_ERROR("VoxelStreamSQLite: failed to begin transaction, instance blocks were not loaded");
-		for (const unsigned int ri : blocks_to_load) {
-			out_blocks[ri].result = RESULT_ERROR;
-		}
+		set_result_codes(out_blocks, blocks_to_load, RESULT_ERROR);
 		con_scope.broken = !recover_after_failed_transaction(*con);
 		return;
 	}

--- a/streams/sqlite/voxel_stream_sqlite.h
+++ b/streams/sqlite/voxel_stream_sqlite.h
@@ -101,10 +101,15 @@ private:
 
 	ConnectionResult get_connection();
 	void recycle_connection(sqlite::Connection *con);
+	void destroy_connection(sqlite::Connection *con);
 
 	struct ScopeRecycle {
 		VoxelStreamSQLite *stream;
 		sqlite::Connection *connection;
+		// Set when the connection could not be recovered after a failed transaction. Such a connection may still be
+		// inside a transaction at the SQLite level, and would then fail every subsequent `begin_transaction` with
+		// "cannot start a transaction within a transaction", so it must not go back into the pool.
+		bool broken = false;
 
 		ScopeRecycle(VoxelStreamSQLite *p_stream, sqlite::Connection *p_connection) :
 				stream(p_stream), connection(p_connection) {
@@ -115,11 +120,15 @@ private:
 		}
 
 		~ScopeRecycle() {
-			stream->recycle_connection(connection);
+			if (broken) {
+				stream->destroy_connection(connection);
+			} else {
+				stream->recycle_connection(connection);
+			}
 		}
 	};
 
-	void flush_cache_to_connection(sqlite::Connection *p_connection);
+	bool flush_cache_to_connection(sqlite::Connection *p_connection);
 
 	static void _bind_methods();
 

--- a/streams/sqlite/voxel_stream_sqlite.h
+++ b/streams/sqlite/voxel_stream_sqlite.h
@@ -51,7 +51,9 @@ public:
 	int get_used_channels_mask() const override;
 
 	void flush() override;
-	void flush_cache();
+	// Returns false if flushing did not complete. In that case, cached blocks are retained if the transaction could
+	// not start, but are lost if the commit itself failed.
+	bool flush_cache();
 
 	// Might improve query performance if saved data is very sparse (like when only edited blocks are saved).
 	void set_key_cache_enabled(bool enable);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -157,6 +157,7 @@ void run_voxel_tests(const testing::TestOptions &options) {
 	VOXEL_TEST(test_voxel_stream_sqlite_key_blob80_encoding);
 	VOXEL_TEST(test_voxel_stream_sqlite_basic);
 	VOXEL_TEST(test_voxel_stream_sqlite_coordinate_format);
+	VOXEL_TEST(test_voxel_stream_sqlite_transaction_recovery);
 #endif
 	VOXEL_TEST(test_sdf_hemisphere);
 	VOXEL_TEST(test_fnl_range);

--- a/tests/voxel/test_stream_sqlite.cpp
+++ b/tests/voxel/test_stream_sqlite.cpp
@@ -1,9 +1,11 @@
 #include "test_stream_sqlite.h"
 #include "../../streams/sqlite/block_location.h"
+#include "../../streams/sqlite/connection.h"
 #include "../../streams/sqlite/voxel_stream_sqlite.h"
 #include "../../streams/voxel_block_serializer_gd.h"
 #include "../../util/containers/container_funcs.h"
 #include "../../util/godot/core/random_pcg.h"
+#include "../../util/godot/core/string.h"
 #include "../../util/math/conv.h"
 #include "../../util/math/vector3i.h"
 #include "../../util/profiling.h"
@@ -333,6 +335,40 @@ void test_voxel_stream_sqlite_key_blob80_encoding() {
 	test_voxel_stream_sqlite_key_blob80_encoding(max_pos, max_lod_index);
 	test_voxel_stream_sqlite_key_blob80_encoding(Vector3i(min_pos.x, max_pos.y, min_pos.z), max_lod_index);
 	test_voxel_stream_sqlite_key_blob80_encoding(Vector3i(max_pos.x, min_pos.y, max_pos.z), max_lod_index);
+}
+
+// When COMMIT fails (typically with SQLITE_BUSY, if another connection on the same file holds the write lock),
+// SQLite does not roll the transaction back: the connection is left inside it. Every later BEGIN on that connection
+// then fails with "cannot start a transaction within a transaction". Since connections are pooled and reused, such a
+// connection would keep failing for the rest of the session. This checks it can be brought back to a usable state.
+void test_voxel_stream_sqlite_transaction_recovery() {
+	using namespace sqlite;
+
+	zylann::testing::TestDirectory test_dir;
+	ZN_TEST_ASSERT(test_dir.is_valid());
+
+	const String database_path = test_dir.get_path().path_join("database.sqlite");
+	const StdString database_path_str = zylann::godot::to_std_string(database_path);
+
+	Connection con;
+	ZN_TEST_ASSERT(con.open(database_path_str.c_str(), BlockLocation::FORMAT_STRING_CSD));
+
+	// Rolling back with no transaction active is a no-op, not an error.
+	ZN_TEST_ASSERT(con.rollback_transaction());
+
+	ZN_TEST_ASSERT(con.begin_transaction());
+
+	// Reproduces the state a failed COMMIT leaves behind: still inside a transaction, so this must fail.
+	// Note this legitimately prints "cannot start a transaction within a transaction" while the test passes;
+	// it is the very error being reproduced here.
+	ZN_TEST_ASSERT(con.begin_transaction() == false);
+
+	ZN_TEST_ASSERT(con.rollback_transaction());
+
+	// The connection has to be usable again. This also covers `sqlite3_reset` returning the error code of the
+	// previous evaluation of a statement, which would otherwise make this first BEGIN fail once more.
+	ZN_TEST_ASSERT(con.begin_transaction());
+	ZN_TEST_ASSERT(con.end_transaction());
 }
 
 } // namespace zylann::voxel::tests

--- a/tests/voxel/test_stream_sqlite.h
+++ b/tests/voxel/test_stream_sqlite.h
@@ -7,6 +7,7 @@ void test_voxel_stream_sqlite_basic();
 void test_voxel_stream_sqlite_coordinate_format();
 void test_voxel_stream_sqlite_key_string_csd_encoding();
 void test_voxel_stream_sqlite_key_blob80_encoding();
+void test_voxel_stream_sqlite_transaction_recovery();
 
 } // namespace zylann::voxel::tests
 


### PR DESCRIPTION
`Connection::open()` never sets a busy timeout, so when several connections of the same stream are open on one file at once (the pool hands them out to a background streaming thread and to `flush()` called from game code alike), a statement that can't take a lock fails immediately with `SQLITE_BUSY` instead of waiting for it.

That is worst on COMMIT: SQLite does **not** roll back a failed COMMIT, so the connection stays inside the transaction. It was then recycled into the pool as if healthy, and every later `begin_transaction()` on it failed with `cannot start a transaction within a transaction` — permanently, since nothing reset it. In practice this shows up as a sustained flood of that error under concurrent load, e.g. a first-launch generation burst on a fresh save racing an explicit `flush()`.

This addresses the two `TODO We should handle busy return codes` at the `begin_transaction()` call sites, and part of `TODO Needs better error rollback handling`:

- `sqlite3_busy_timeout()` in `Connection::open()`, so contending connections wait instead of failing outright. Kept modest (1s) because `flush()` is reachable from the main thread and exceeding it is no longer fatal.
- `Connection::rollback_transaction()`, used to bring a connection back to a usable state after a failed transaction. It also clears leftover statement state, since `sqlite3_reset()` returns the error of the *previous* evaluation, and the recovered connection would otherwise fail its next `BEGIN` once more.
- Connections that still can't be recovered are dropped instead of returned to the pool.
- Added `test_voxel_stream_sqlite_transaction_recovery`, which reproduces the stuck state deterministically (no threading involved). It legitimately prints the "cannot start a transaction within a transaction" error while passing — that's the condition under test.

**Not fixed here:** `VoxelStreamCache::flush()` clears its dirty blocks as it hands them to the save callback, before the caller's COMMIT is confirmed, so blocks caught in a failed flush are lost with no way to retry. This change makes that far rarer but doesn't close it — it seemed like it needs a design decision (unbounded cache growth if commits keep failing) rather than a quick patch, so I left it out. It may be worth a look as a candidate cause for #597, which reports missing chunks after a *normal* shutdown.

**Testing:** Windows, editor target, `precision=double`, GDExtension, godot-cpp master. The SQLite test suite passes, including the new test. Note `test_voxel_buffer_metadata_gd` fails in this configuration both with and without this change (verified against unmodified master) — it appears to be a pre-existing, unrelated issue specific to double precision. Reproduced the original error flood on a fresh save under concurrent generation + an early dig, confirmed it's gone after this change. Not tested on Linux/macOS/mono or as an engine module build.