### PR TITLE
Fix --headless crash: no threaded graphics resource building

### DIFF
--- a/engine/voxel_engine.cpp
+++ b/engine/voxel_engine.cpp
@@ -5,6 +5,7 @@
 #include "../streams/load_all_blocks_data_task.h"
 #include "../streams/load_block_data_task.h"
 #include "../streams/save_block_data_task.h"
+#include "../util/godot/classes/display_server.h"
 #include "../util/godot/classes/os.h"
 #include "../util/godot/classes/project_settings.h"
 #include "../util/godot/classes/rd_sampler_state.h"
@@ -88,6 +89,19 @@ VoxelEngine::~VoxelEngine() {
 static bool auto_detect_threaded_graphics_resource_building_support() {
 	const ProjectSettings *project = ProjectSettings::get_singleton();
 	ZN_ASSERT_RETURN_V(project != nullptr, false);
+
+	// A headless DisplayServer installs the dummy rasterizer
+	// (DisplayServerHeadless::create_func -> RasterizerDummy::make_current()), whose storage is not
+	// safe for concurrent access from multiple threads. The project's rendering_method/
+	// rendering_driver settings keep reporting their configured values in that case, so they
+	// cannot be used to detect it.
+	// This is a workaround for a Godot issue (the renderer is not thread-safe in headless mode):
+	// https://github.com/godotengine/godot/issues/121949
+	// It can be removed once that is fixed in Godot itself.
+	const DisplayServer *display_server = DisplayServer::get_singleton();
+	if (display_server == nullptr || display_server->get_name() == "headless") {
+		return false;
+	}
 
 	const zylann::godot::RenderThreadModel rendering_thread_model = zylann::godot::get_render_thread_model(*project);
 	const zylann::godot::RenderMethod rendering_method = zylann::godot::get_current_rendering_method();


### PR DESCRIPTION
### Problem

Running a project that uses `VoxelTerrain` with `godot --headless` crashes with SIGSEGV as soon as enough mesh blocks are produced at once. Repro: take a project with default rendering settings (`rendering_method = forward_plus`, `rendering_driver = vulkan`, `rendering/driver/threads/thread_model = Safe`), stream in enough terrain to queue up a few thousand mesh blocks, and start it with `--headless`. The log fills with RID errors from the dummy rasterizer and the process dies on a `WorkerThreadPool` thread; the same project run windowed is fine.

Backtrace of the signal-carrying thread (always a worker, never the main thread):

```
MeshBlockTask::run -> zylann::voxel::build_mesh -> ArrayMesh::add_surface_from_arrays -> <dummy rasterizer>
```

### Root cause

`auto_detect_threaded_graphics_resource_building_support()` (`engine/voxel_engine.cpp:88-118` on master, `:89-119` on `v1.6`) decides whether mesh resources may be built off the main thread. It looks at three things: the project's `rendering/driver/threads/thread_model`, `get_current_rendering_method()` and `get_current_rendering_driver()`. None of them sees a headless run:

- `--headless` only rewrites the **display** and **audio** driver (`main/main.cpp`, `--headless` branch: `audio_driver = NULL_AUDIO_DRIVER; display_driver = NULL_DISPLAY_DRIVER;`). `rendering_method` / `rendering_driver` keep resolving to the project settings and are handed to `OS::set_current_rendering_method()` / `set_current_rendering_driver_name()` unchanged — so godot_voxel still reads `forward_plus` / `vulkan`.
- The dummy rasterizer is installed by the **DisplayServer**, not by the rendering method: `DisplayServerHeadless::create_func()` calls `RasterizerDummy::make_current()` (`servers/display/display_server_headless.cpp`).

With default project settings the function therefore returns `true` under `--headless`, and `meshers/mesh_block_task.cpp:581` (`if (require_visual && …is_threaded_graphics_resource_building_enabled())`) builds `ArrayMesh` / RenderingServer resources directly from worker threads against a rasterizer that is not safe for concurrent access. Hence the RID error flood and the crash.

### Fix

One include plus an early return in the auto-detect function: if there is no `DisplayServer` singleton, or its name is `"headless"`, threaded graphics resource building is reported as unsupported.

- **Minimal.** No new project setting, no new abstraction file, no change to `mesh_block_task.cpp` — the `else` branch there already exists (`_has_mesh_resource = false`) and takes the main-thread path, which is the correct behaviour on a dummy renderer. For every non-headless run `get_name()` is never `"headless"` and the rest of the function is reached unchanged, so this cannot alter behaviour in any environment where the current logic is already right.
- **`get_name() == "headless"` is Godot's own idiom** for this test, used in `servers/display/display_server.cpp` (`if (get_singleton() && get_singleton()->get_name() == "headless") { … }`) and backed by `DisplayServerHeadless::get_name() const override { return "headless"; }`. It avoids depending on anything internal or on a specific rasterizer type.
- **Both editions are covered.** `util/godot/classes/display_server.h` already exists in the tree and wraps the module (`servers/display_server.h` / `servers/display/display_server.h` depending on Godot version) and the GDExtension (`godot_cpp/classes/display_server.hpp` + `using namespace godot;`) case, so the patch needs no `#ifdef` of its own. `DisplayServer::get_singleton()` and `String get_name() const` exist in both; `String::operator==(const char *)` exists in godot-cpp as well. Only the GDExtension edition was built and run for this report — the module edition compiles against the same wrapper but was not exercised.
- The `nullptr` branch is defensive and matches the existing style of the function (`ZN_ASSERT_RETURN_V(project != nullptr, false)`): with `tests=yes` there may be no DisplayServer, and `false` is the safe answer. In normal runs the function is reached via `VoxelEngineUpdater::ensure_existence()`, i.e. well after the DisplayServer exists.

### Testing

Empirically isolated with two builds from the same source tree and the same SCons command line, the only difference being this patch:

| Build | Command | Runs | Result |
|---|---|---|---|
| unpatched (control) | `godot --headless …` | 3 | 2× SIGSEGV in a `WorkerThreadPool` worker (`si_addr = 0xd5`, LWP ≠ PID, backtrace as above), 1× completed. Verbose log: `Auto-detected threaded graphics resource building: true` |
| patched | `godot --headless …` (identical) | 3 | 3/3 completed, no crash, no RID errors. Verbose log: `Auto-detected threaded graphics resource building: false` |
| patched | windowed (same project) | 1 | completed, `Auto-detected threaded graphics resource building: true` — unchanged from before |

Environment: Godot 4.7.1-stable, Linux x86_64 (Fedora, gcc 16.1.1, SCons 4.10.1); godot_voxel `595f52ee` (`v1.6`), GDExtension edition, `target=editor`, built against godot-cpp `godot-4.5-stable` (`e83fd090`). Load: a `VoxelTerrain` at 0.2 m voxel size, ~26,000 data blocks streamed in headless; project settings at defaults for rendering method/driver/thread model. The patch also applies cleanly to current `master` (one line of offset).

### Alternative considered

A kill-switch project setting (or reviving the commented-out `VoxelEngine::set_threaded_graphics_resource_building_enabled()` / its `_b_` binding in `engine/voxel_engine_gd.cpp`) would let users turn threaded resource building off by hand. That was rejected: the setter and its binding are dead code today, reviving them means adding public API and a documented setting for what is really a detection bug, and it would not fix anything for users who never learn the setting exists — every headless CI run would still crash out of the box on default settings. The early return addresses the actual root cause (the DisplayServer, not the rendering method, decides which rasterizer is active) and needs no new surface.

### Note on #733

The auto-detection lives in `try_initialize_gpu_features()`, which was introduced by `1554ae49` ("Workaround crash in release GDExtension builds", see #733) and got its current settings-based form in `61ab8295`. Headless was never part of that design — this PR only adds the missing case and leaves the behaviour for every non-headless configuration bit-for-bit identical.
