### PR TITLE
Fix small typo in type descrption

### DIFF
--- a/doc/classes/VoxelMesherTransvoxel.xml
+++ b/doc/classes/VoxelMesherTransvoxel.xml
@@ -4,7 +4,7 @@
 		Implements isosurface generation (smooth voxels) using the [url=https://transvoxel.org/]Transvoxel[/url] algorithm.
 	</brief_description>
 	<description>
-		Uses the [url=https://transvoxel.org/]Transvoxel[/url] algorithm to polygonizes smooth voxels. Note: if you want to use LOD, you will need special vertex shader code to properly render seams (otherwise they will render as thin sheets between chunks). Check [url]https://voxel-tools.readthedocs.io/en/latest/smooth_terrain/#transvoxel[/url] or demos featuring smooth terrain for more information.
+		Uses the [url=https://transvoxel.org/]Transvoxel[/url] algorithm to polygonize smooth voxels. Note: if you want to use LOD, you will need special vertex shader code to properly render seams (otherwise they will render as thin sheets between chunks). Check [url]https://voxel-tools.readthedocs.io/en/latest/smooth_terrain/#transvoxel[/url] or demos featuring smooth terrain for more information.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Just a tiny typo I noticed.

I'm actually not 100% I'm supposed to be editing this xml manually. But I it does seem like the source used to generate final docs markdown? If there's another way, please do let me know!